### PR TITLE
Update vc_multi to always use .wav as file extension.

### DIFF
--- a/infer-web.py
+++ b/infer-web.py
@@ -1,4 +1,5 @@
 from multiprocessing import cpu_count
+from my_utils import rename_as_wav_extension
 import threading
 from time import sleep
 from subprocess import Popen
@@ -251,14 +252,15 @@ def vc_multi(
                 resample_sr,
             )
             if "Success" in info:
+                output_wav_file_name = rename_as_wav_extension(os.path.basename(path))
                 try:
                     tgt_sr, audio_opt = opt
                     wavfile.write(
-                        "%s/%s" % (opt_root, os.path.basename(path)), tgt_sr, audio_opt
+                        "%s/%s" % (opt_root, output_wav_file_name), tgt_sr, audio_opt
                     )
                 except:
                     info += traceback.format_exc()
-            infos.append("%s->%s" % (os.path.basename(path), info))
+            infos.append("%s->%s" % (output_wav_file_name, info))
             yield "\n".join(infos)
         yield "\n".join(infos)
     except:

--- a/infer-web.py
+++ b/infer-web.py
@@ -1,5 +1,5 @@
 from multiprocessing import cpu_count
-from my_utils import rename_as_wav_extension
+from my_utils import rename_wav_as_extension
 import threading
 from time import sleep
 from subprocess import Popen
@@ -251,8 +251,8 @@ def vc_multi(
                 filter_radius,
                 resample_sr,
             )
+            output_wav_file_name = rename_wav_as_extension(os.path.basename(path))
             if "Success" in info:
-                output_wav_file_name = rename_as_wav_extension(os.path.basename(path))
                 try:
                     tgt_sr, audio_opt = opt
                     wavfile.write(

--- a/infer-web.py
+++ b/infer-web.py
@@ -251,16 +251,17 @@ def vc_multi(
                 filter_radius,
                 resample_sr,
             )
-            output_wav_file_name = rename_wav_as_extension(os.path.basename(path))
+
             if "Success" in info:
                 try:
                     tgt_sr, audio_opt = opt
+                    output_wav_file_name = rename_wav_as_extension(os.path.basename(path))
                     wavfile.write(
                         "%s/%s" % (opt_root, output_wav_file_name), tgt_sr, audio_opt
                     )
                 except:
                     info += traceback.format_exc()
-            infos.append("%s->%s" % (output_wav_file_name, info))
+            infos.append("%s->%s" % (os.path.basename(path), info))
             yield "\n".join(infos)
         yield "\n".join(infos)
     except:

--- a/my_utils.py
+++ b/my_utils.py
@@ -29,7 +29,6 @@ def rename_wav_as_extension(file_name):
       For example,file `abc.mp3` will be renamed as `abc.wav`
     * If a file does not have an extension, `.wav` will be appended as extension
       For example,file `abc` will be renamed as `abc.wav`
-    `
     '''
     if '.' not in file_name:
         return file_name + '.wav'

--- a/my_utils.py
+++ b/my_utils.py
@@ -1,5 +1,6 @@
 import ffmpeg
 import numpy as np
+import re
 
 
 def load_audio(file, sr):
@@ -19,3 +20,17 @@ def load_audio(file, sr):
         raise RuntimeError(f"Failed to load audio: {e}")
 
     return np.frombuffer(out, np.float32).flatten()
+
+
+def rename_as_wav_extension(file_name):
+    '''
+    Renames file_name extension as .wav
+    * If a file has an extension different from `.wav` it will be renamed to `.wav`
+      For example,file `abc.mp3` will be renamed as `abc.wav`
+    * If a file does not have an extension, `.wav` will be appended as extension
+      For example,file `abc` will be renamed as `abc.wav`
+    `
+    '''
+    if '.' not in file_name:
+        return file_name + '.wav'
+    return re.sub(r'\.\w*?$', '.wav', file_name)

--- a/my_utils.py
+++ b/my_utils.py
@@ -22,7 +22,7 @@ def load_audio(file, sr):
     return np.frombuffer(out, np.float32).flatten()
 
 
-def rename_as_wav_extension(file_name):
+def rename_wav_as_extension(file_name):
     '''
     Renames file_name extension as .wav
     * If a file has an extension different from `.wav` it will be renamed to `.wav`

--- a/test/test_my_utils.py
+++ b/test/test_my_utils.py
@@ -1,12 +1,12 @@
 import unittest
-from my_utils import rename_as_wav_extension
+from my_utils import rename_wav_as_extension
 
 class TestStringMethods(unittest.TestCase):
 
     def test_alwaysRenameFileAsWav(self):
-        self.assertEqual(rename_as_wav_extension('a_bc.mp3'), 'a_bc.wav')
-        self.assertEqual(rename_as_wav_extension('ab+c'), 'ab+c.wav')
-        self.assertEqual(rename_as_wav_extension('a-bc.flac.mp3'), 'a-bc.flac.wav')
+        self.assertEqual(rename_wav_as_extension('a_bc.mp3'), 'a_bc.wav')
+        self.assertEqual(rename_wav_as_extension('ab+c'), 'ab+c.wav')
+        self.assertEqual(rename_wav_as_extension('a-bc.flac.mp3'), 'a-bc.flac.wav')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_my_utils.py
+++ b/test/test_my_utils.py
@@ -1,0 +1,13 @@
+import unittest
+from my_utils import rename_as_wav_extension
+
+class TestStringMethods(unittest.TestCase):
+
+    def test_alwaysRenameFileAsWav(self):
+        self.assertEqual(rename_as_wav_extension('a_bc.mp3'), 'a_bc.wav')
+        self.assertEqual(rename_as_wav_extension('ab+c'), 'ab+c.wav')
+        self.assertEqual(rename_as_wav_extension('a-bc.flac.mp3'), 'a-bc.flac.wav')
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Currnetly in vc multi convert mode, regardless the input file format is, the output file extension is always the original one. This pull request make sure the output file extension is `.wav`

现在语音转换的源文件支持非`.wav`格式的文件（ffprobe/ffmpeg会自动检测源文件格式并转换），但是输出时文件名会被输出为源文件的拓展名，文件内容则永远是wave文件。

比如我有一个`apc.MP3` 文件，转换之后输出名也是`apc.MP3` ，但是转换后的格式其实是`.wav`