### PR TITLE
Off-by-one in extract_feature_print.py on macOS and numpy np.int

### DIFF
--- a/extract_f0_print.py
+++ b/extract_f0_print.py
@@ -86,7 +86,7 @@ class FeatureInput(object):
         # use 0 or 1
         f0_mel[f0_mel <= 1] = 1
         f0_mel[f0_mel > self.f0_bin - 1] = self.f0_bin - 1
-        f0_coarse = np.rint(f0_mel).astype(np.int)
+        f0_coarse = np.rint(f0_mel).astype(np.int64)
         assert f0_coarse.max() <= 255 and f0_coarse.min() >= 1, (
             f0_coarse.max(),
             f0_coarse.min(),

--- a/extract_feature_print.py
+++ b/extract_feature_print.py
@@ -1,10 +1,17 @@
-import os, sys, traceback
+import os, sys, traceback,platform
+
+debug_macos = True if(platform.system() == "Darwin") else False
 
 # device=sys.argv[1]
 n_part = int(sys.argv[2])
 i_part = int(sys.argv[3])
 if len(sys.argv) == 5:
     exp_dir = sys.argv[4]
+    version = sys.argv[5]
+elif debug_macos:  #Not checked for cross-platform compatibility, but on macos there's an off-by-one error.
+    i_gpu = sys.argv[3]
+    exp_dir = sys.argv[4]
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(i_gpu)
     version = sys.argv[5]
 else:
     i_gpu = sys.argv[4]

--- a/gui.py
+++ b/gui.py
@@ -102,7 +102,7 @@ class RVC:
         ) + 1
         f0_mel[f0_mel <= 1] = 1
         f0_mel[f0_mel > 255] = 255
-        f0_coarse = np.rint(f0_mel).astype(np.int)
+        f0_coarse = np.rint(f0_mel).astype(np.int64)
         return f0_coarse, f0bak  # 1-0
 
     def infer(self, feats: torch.Tensor) -> np.ndarray:

--- a/vc_infer_pipeline.py
+++ b/vc_infer_pipeline.py
@@ -125,7 +125,7 @@ class VC(object):
         ) + 1
         f0_mel[f0_mel <= 1] = 1
         f0_mel[f0_mel > 255] = 255
-        f0_coarse = np.rint(f0_mel).astype(np.int)
+        f0_coarse = np.rint(f0_mel).astype(np.int64)
         return f0_coarse, f0bak  # 1-0
 
     def vc(


### PR DESCRIPTION
### More information needed
### Haven't tested on other platforms!

### Changes:

1. Using np.int64 instead of np.int in `gui.py`,`extract_f0_print.py` and `vc_infer_pipeline.py` to correspond to numpy's deprecating np.int.
2. Added platform test in `extract_feature_print.py` , in that on macOS there's been one off-by-one error, causing `version = sys.argv[6]` to evaluate to out of range, `i_gpu` and `exp_dir` all getting the wrong value, and `FileNotFoundError: [Errno 2] No such file or directory: '<PathTo>/3_feature256'(3_feature768) ` thereon.

-> 2) The problem hasn't been traced thoroughly, so I'm not sure what exactly the situation was. For my device, `i_gpu` and `os.environ["CUDA_VISIBLE_DEVICES"]` in the new branch could be omitted(commented out), leaving it the same as in  `if len(sys.argv) == 5`
```
    exp_dir = sys.argv[4]
    version = sys.argv[5]
```

![off-by-one](https://github.com/RVC-Project/Retrieval-based-Voice-Conversion-WebUI/assets/66196038/9c71594f-a36d-43f1-917e-a1e9a887e16f)
