### PR TITLE
Exclude python3.11 from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["lj1995"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.8,<3.11"
 torch = "^2.0.0"
 torchaudio = "^2.0.1"
 Cython = "^0.29.34"


### PR DESCRIPTION
On Fedora 38, default python version is 3.11 and this version seems not supported by numba.
So fix pyproject.toml