### PR TITLE
Replace deprecated Numpy function `np.int`.

### DIFF
--- a/extract_f0_print.py
+++ b/extract_f0_print.py
@@ -86,7 +86,7 @@ class FeatureInput(object):
         # use 0 or 1
         f0_mel[f0_mel <= 1] = 1
         f0_mel[f0_mel > self.f0_bin - 1] = self.f0_bin - 1
-        f0_coarse = np.rint(f0_mel).astype(np.int)
+        f0_coarse = np.rint(f0_mel).astype(int)
         assert f0_coarse.max() <= 255 and f0_coarse.min() >= 1, (
             f0_coarse.max(),
             f0_coarse.min(),


### PR DESCRIPTION
It’s an alias for just `int` and it’s being deprecated:
https://numpy.org/devdocs/release/1.20.0-notes.html