### PR TITLE
remove specify version

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,6 @@ poetry install
 pip install -r requirements.txt
 ```
 
-**注意**
-1. 英特尔`MacOS`下使用pip安装`faiss 1.7.0`以上版本会导致抛出段错误，在手动安装时，如需安装最新版，请使用`conda`；如只能使用`pip`，请指定使用`1.7.0`版本。
-2. `MacOS`下如`faiss`安装失败，可尝试通过`brew`安装`Swig`
-
-```bash
-brew install swig
-```
-
 ## 其他预模型准备
 RVC需要其他一些预模型来推理和训练。
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -56,8 +56,6 @@ poetry install
 ```
 You can also use pip to install the dependencies
 
-**Notice**: `faiss 1.7.2` will raise Segmentation Fault: 11 under `MacOS`, please use `pip install faiss-cpu==1.7.0` if you use pip to install it manually.
-
 ```bash
 pip install -r requirements.txt
 ```

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -61,8 +61,6 @@ poetry install
 
 pipでも依存関係のインストールが可能です:
 
-**注意**:`faiss 1.7.2`は`macOS`で`Segmentation Fault: 11`を起こすので、マニュアルインストールする場合は、 `pip install faiss-cpu==1.7.0`を実行してください。
-
 ```bash
 pip install -r requirements.txt
 ```

--- a/docs/README.ko.han.md
+++ b/docs/README.ko.han.md
@@ -58,8 +58,6 @@ poetry install
 ```
 pip를 活用하여依存를 設置하여도 無妨합니다.
 
-**公知**: `MacOS`에서 `faiss 1.7.2`를 使用하면 Segmentation Fault: 11 誤謬가 發生할 수 있습니다. 手動으로 pip를 使用하여 設置하는境遇 `pip install faiss-cpu==1.7.0`을 使用해야 합니다.
-
 ```bash
 pip install -r requirements.txt
 ```

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -64,8 +64,6 @@ poetry install
 
 pip를 활용하여 dependencies를 설치하여도 무방합니다.
 
-**공지**: `MacOS`에서 `faiss 1.7.2`를 사용하면 Segmentation Fault: 11 오류가 발생할 수 있습니다. 수동으로 pip를 사용하여 설치하는 경우 `pip install faiss-cpu==1.7.0`을 사용해야 합니다.
-
 ```bash
 pip install -r requirements.txt
 ```


### PR DESCRIPTION
from 769cf35
Now we don't need to do anything special right now on mac.
Besides, there are some cases where faiss 1.7.0 is not available