### PR TITLE
Add global step to saved checkpoint filename

### DIFF
--- a/train_nsf_sim_cache_sid_load_pretrain.py
+++ b/train_nsf_sim_cache_sid_load_pretrain.py
@@ -557,7 +557,7 @@ def train_and_evaluate(
                         ckpt,
                         hps.sample_rate,
                         hps.if_f0,
-                        hps.name + "_e%s" % epoch,
+                        hps.name + "_e%s_s%s" % (epoch, global_step),
                         epoch,
                         hps.version,
                         hps,


### PR DESCRIPTION
This update enhances the code by including the global step in the filename of the saved checkpoint. Previously, only the epoch number was used as the identifier. With the addition of the global step, it becomes easier to track the progress and distinguish between different saves file. 

This change improves the tracking and management of saved checkpoints, facilitating better monitoring of the training process.