### PR TITLE
Fix the index out of bounds bug in extract_feature_print.py

### DIFF
--- a/extract_feature_print.py
+++ b/extract_feature_print.py
@@ -3,7 +3,7 @@ import os, sys, traceback
 # device=sys.argv[1]
 n_part = int(sys.argv[2])
 i_part = int(sys.argv[3])
-if len(sys.argv) == 5:
+if len(sys.argv) == 6:
     exp_dir = sys.argv[4]
     version = sys.argv[5]
 else:


### PR DESCRIPTION
Check if the length of sys.argv is 6, instead of 5, to cover sys.argv[5]. Otherwise when the length is 6, it runs the else body and tries to access sys.argv[6] in line 13, which is an error.