### PR TITLE
Fix OpenBLAS warning

### DIFF
--- a/infer-web.py
+++ b/infer-web.py
@@ -10,6 +10,7 @@ import warnings
 import numpy as np
 import torch
 
+os.environ['OPENBLAS_NUM_THREADS'] = '1'
 os.environ["no_proxy"] = "localhost, 127.0.0.1, ::1"
 import logging
 import threading


### PR DESCRIPTION
Fixes the error msg: "OpenBLAS warning: precompiled NUM_THREADS exceeded, adding auxiliary array for thread metadata"