### PR TITLE
Improve boolean parsing from command line arguments

### DIFF
--- a/infer_batch_rvc.py
+++ b/infer_batch_rvc.py
@@ -100,7 +100,7 @@ opt_path = sys.argv[5]
 model_path = sys.argv[6]
 index_rate = float(sys.argv[7])
 device = sys.argv[8]
-is_half = bool(sys.argv[9])
+is_half = sys.argv[9].lower() != "false"
 filter_radius = int(sys.argv[10])
 resample_sr = int(sys.argv[11])
 rms_mix_rate = float(sys.argv[12])


### PR DESCRIPTION
This PR improves the parsing of `is_half` in `infer_batch_rvc.py`.

Previously, all non-empty strings were considered `True`, including the string "False".
This was confusing for users. 

With this change, the string "False" (regardless of case and leading/trailing white spaces) will be correctly parsed as `False`. All other non-empty strings will be parsed as `True`, as before.

I think that [myinfer-v2-0528.py](https://huggingface.co/lj1995/VoiceConversionWebUI/blob/main/myinfer-v2-0528.py) needs to be changed as well.