### PR TITLE
Use sys.executable to determine --pycmd

### DIFF
--- a/config.py
+++ b/config.py
@@ -38,7 +38,7 @@ class Config:
         parser = argparse.ArgumentParser()
         parser.add_argument("--port", type=int, default=7865, help="Listen port")
         parser.add_argument(
-            "--pycmd", type=str, default=exe or "python", help="Python command"
+            "--pycmd", type=str, default=exe, help="Python command"
         )
         parser.add_argument("--colab", action="store_true", help="Launch in colab")
         parser.add_argument(

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 import torch
 from multiprocessing import cpu_count
 
@@ -33,10 +34,11 @@ class Config:
 
     @staticmethod
     def arg_parse() -> tuple:
+        exe = sys.executable or "python"
         parser = argparse.ArgumentParser()
         parser.add_argument("--port", type=int, default=7865, help="Listen port")
         parser.add_argument(
-            "--pycmd", type=str, default="python", help="Python command"
+            "--pycmd", type=str, default=exe or "python", help="Python command"
         )
         parser.add_argument("--colab", action="store_true", help="Launch in colab")
         parser.add_argument(


### PR DESCRIPTION
In some systems, `python` may not correctly refer to the virtual environment's `python` used for webui, or it even refers to Python 2. Also in Windows, when the webui is run directly through `venv\Scripts\python` without activating the virtual environment, the system python will be picked instead of the one inside virtual environment. This will result in `ImportError` later due to wrong Python being selected.

Please see #463 for the rationale of this change.