### PR TITLE
Fix dependency error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ pyworld>=0.3.2
 httpx==0.23.0
 #onnxruntime-gpu
 torchcrepe==0.0.20
+fastapi==0.88


### PR DESCRIPTION
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts. lightning 2.0.2 requires fastapi<0.89.0,>=0.69.0, but you have fastapi 0.100.0 which is incompatible. so-vits-svc-fork 3.14.1 requires fastapi==0.88, but you have fastapi 0.100.0 which is incompatible.