### PR TITLE
fix mps in gui-v1.py

### DIFF
--- a/gui_v1.py
+++ b/gui_v1.py
@@ -568,7 +568,7 @@ if __name__ == "__main__":
                 if sys.platform == "darwin":
                     outdata[:] = self.output_wav[:].cpu().numpy()[:, np.newaxis]
                 else:
-                    outdata[:] = self.output_wav[:].cpu().numpy()
+                    outdata[:] = self.output_wav[:].repeat(2, 1).t().cpu().numpy()
             total_time = time.perf_counter() - start_time
             self.window["infer_time"].update(int(total_time * 1000))
             print("infer time:" + str(total_time))


### PR DESCRIPTION
This modification resolves the issue of `gui-v1.py` not functioning on macOS. The changes include:

- Altering the channels parameter to `1` instead of `2` to prevent errors with the `sd` library.
- Setting `PYTORCH_ENABLE_MPS_FALLBACK` to `1`.
- Selecting the MPS device if it's available.

However, these adjustments are not a flawless solution:
```
cor_nom = cor_nom.cpu()
cor_den = cor_den.cpu()
```
The above lines of code are necessary for it to work with the CPU. I've tried using Metal Performance Shaders (MPS) but a significantly large negative sola_offset is observed, which is not the desired behaviour.
Also, these changes introduce a stuttering issue, though it's unclear whether this is the same issue mentioned in issue #764.
I hope someone can provide a reliable solution.