### PR TITLE
Fix dependency conflict in last pull request

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ praat-parselmouth>=0.4.2
 Pillow>=9.1.1
 resampy>=0.4.2
 scikit-learn
-starlette>=0.25.0
 tensorboard
 tqdm>=4.63.1
 tornado>=6.1


### PR DESCRIPTION
The conflict is caused by:
    The user requested starlette>=0.25.0
    fastapi 0.88.0 depends on starlette==0.22.0

fastapi 0.88.0 package will resolve dependency automatically, remove the starlette>=0.25.0 will fix the conflict.