### PR TITLE
add browser tab title

### DIFF
--- a/infer-web.py
+++ b/infer-web.py
@@ -1301,7 +1301,7 @@ def export_onnx(ModelPath, ExportedPath):
     return "Finished"
 
 
-with gr.Blocks() as app:
+with gr.Blocks(title="RVC WebUI") as app:
     gr.Markdown(
         value=i18n(
             "本软件以MIT协议开源, 作者不对软件具备任何控制力, 使用软件者、传播软件导出的声音者自负全责. <br>如不认可该条款, 则不能使用或引用软件包内任何代码和文件. 详见根目录<b>LICENSE</b>."


### PR DESCRIPTION
Adds a nice title to the browser tab instead of the generic "Gradio" one.
I guess it could be made into a translatable with i18n but... I don't know Chinese.

<img width="489" alt="SCR-20230717-omi" src="https://github.com/RVC-Project/Retrieval-based-Voice-Conversion-WebUI/assets/457678/60353906-f53b-42cf-81f4-08be32d5e8b0">

Thanks for a great project!
