### PR TITLE
fix failed building pyworld

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ absl-py>=1.2.0
 audioread
 uvicorn>=0.21.1
 colorama>=0.4.5
-pyworld>=0.3.2
+pyworld==0.3.2
 httpx==0.23.0
 #onnxruntime-gpu
 torchcrepe==0.0.20


### PR DESCRIPTION
Building wheels for collected packages: pyworld
error: subprocess-exited-with-error

× Building wheel for pyworld (pyproject.toml) did not run successfully. │ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip. Building wheel for pyworld (pyproject.toml) ... error ERROR: Failed building wheel for pyworld
Failed to build pyworld
ERROR: Could not build wheels for pyworld, which is required to install pyproject.toml-based projects