### PR TITLE
some error building pyworld

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ absl-py>=1.2.0
 audioread
 uvicorn>=0.21.1
 colorama>=0.4.5
-pyworld>=0.3.2
+pyworld==0.3.2
 httpx==0.23.0
 #onnxruntime-gpu
 torchcrepe==0.0.20


### PR DESCRIPTION
 × Building wheel for pyworld (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  Building wheel for pyworld (pyproject.toml) ... error
  ERROR: Failed building wheel for pyworld
  Building wheel for antlr4-python3-runtime (setup.py) ... done
  Created wheel for antlr4-python3-runtime: filename=antlr4_python3_runtime-4.8-py3-none-any.whl size=141210 sha256=e81137dc4dd676c814cbce5303bf5b687232f3bd7861df8d666cfe05ae199b3e
  Stored in directory: /root/.cache/pip/wheels/a7/20/bd/e1477d664f22d99989fd28ee1a43d6633dddb5cb9e801350d5
Successfully built fairseq antlr4-python3-runtime
Failed to build pyworld
ERROR: Could not build wheels for pyworld, which is required to install pyproject.toml-based projects