### PR TITLE
Move `cor_nom`, `cor_den` to mps (`gui_v1.py`)

### DIFF
--- a/gui_v1.py
+++ b/gui_v1.py
@@ -555,8 +555,11 @@ if __name__ == "__main__":
                 )
                 + 1e-8
             )
-            _, sola_offset = torch.max(cor_nom[0, 0] / cor_den[0, 0])
-            sola_offset = sola_offset.item()
+            if sys.platform == "darwin":
+                _, sola_offset = torch.max(cor_nom[0, 0] / cor_den[0, 0])
+                sola_offset = sola_offset.item()
+            else:
+                sola_offset = torch.argmax(cor_nom[0, 0] / cor_den[0, 0])
             print("sola offset: " + str(int(sola_offset)))
             self.output_wav[:] = infer_wav[sola_offset : sola_offset + self.block_frame]
             self.output_wav[: self.crossfade_frame] *= self.fade_in_window

--- a/gui_v1.py
+++ b/gui_v1.py
@@ -555,10 +555,8 @@ if __name__ == "__main__":
                 )
                 + 1e-8
             )
-            if sys.platform == "darwin":
-                cor_nom = cor_nom.cpu()
-                cor_den = cor_den.cpu()
-            sola_offset = torch.argmax(cor_nom[0, 0] / cor_den[0, 0])
+            _, sola_offset = torch.max(cor_nom[0, 0] / cor_den[0, 0])
+            sola_offset = sola_offset.item()
             print("sola offset: " + str(int(sola_offset)))
             self.output_wav[:] = infer_wav[sola_offset : sola_offset + self.block_frame]
             self.output_wav[: self.crossfade_frame] *= self.fade_in_window


### PR DESCRIPTION
I initially faced an issue where a large negative sola_offset was generated when using MPS. My original solution, outlined in pull request #769, was to transfer these to the CPU, but this approach was far from optimal. I later came across [this](https://github.com/pytorch/pytorch/issues/92311) GitHub issue, which revealed the true source of the problem: the argmax() function was behaving abnormally on macOS. As a result, in this current commit, I provide an alternative solution which should function uniformly across all platforms.