### PR TITLE
bugfix: fix .venv file version to 3.8

### DIFF
--- a/venv.sh
+++ b/venv.sh
@@ -1,1 +1,1 @@
-python3 -m venv .venv
+python3.8 -m venv .venv


### PR DESCRIPTION
If the user has something other than 3.8 installed as the default on their computer, it may cause conflicts. Therefore, I fixed it to 3.8 to avoid any issues.