### PR TITLE
replace np.int with np.int32

### DIFF
--- a/gui_v0.py
+++ b/gui_v0.py
@@ -131,7 +131,7 @@ class RVC:
         ) + 1
         f0_mel[f0_mel <= 1] = 1
         f0_mel[f0_mel > 255] = 255
-        f0_coarse = np.rint(f0_mel).astype(np.int)
+        f0_coarse = np.rint(f0_mel).astype(np.int32)
         return f0_coarse, f0bak  # 1-0
 
     def infer(self, feats: torch.Tensor) -> np.ndarray:

--- a/guidml.py
+++ b/guidml.py
@@ -145,7 +145,7 @@ class RVC:
         ) + 1
         f0_mel[f0_mel <= 1] = 1
         f0_mel[f0_mel > 255] = 255
-        f0_coarse = np.rint(f0_mel).astype(np.int)
+        f0_coarse = np.rint(f0_mel).astype(np.int32)
         return f0_coarse, f0bak  # 1-0
 
     def infer(self, feats: torch.Tensor) -> np.ndarray:

--- a/rvc_for_realtime.py
+++ b/rvc_for_realtime.py
@@ -100,7 +100,7 @@ class RVC:
         ) + 1
         f0_mel[f0_mel <= 1] = 1
         f0_mel[f0_mel > 255] = 255
-        f0_coarse = np.rint(f0_mel).astype(np.int)
+        f0_coarse = np.rint(f0_mel).astype(np.int32)
         return f0_coarse, f0bak
 
     def get_f0(self, x, f0_up_key, n_cpu, method="harvest"):

--- a/tools/infer/infer-pm-index256.py
+++ b/tools/infer/infer-pm-index256.py
@@ -112,7 +112,7 @@ def get_f0(x, p_len, f0_up_key=0):
     f0_mel[f0_mel <= 1] = 1
     f0_mel[f0_mel > 255] = 255
     # f0_mel[f0_mel > 188] = 188
-    f0_coarse = np.rint(f0_mel).astype(np.int)
+    f0_coarse = np.rint(f0_mel).astype(np.int32)
     return f0_coarse, f0bak
 
 

--- a/vc_infer_pipeline.py
+++ b/vc_infer_pipeline.py
@@ -158,7 +158,7 @@ class VC(object):
         ) + 1
         f0_mel[f0_mel <= 1] = 1
         f0_mel[f0_mel > 255] = 255
-        f0_coarse = np.rint(f0_mel).astype(np.int)
+        f0_coarse = np.rint(f0_mel).astype(np.int32)
         return f0_coarse, f0bak  # 1-0
 
     def vc(


### PR DESCRIPTION
With `numpy 1.20+` causes
```log
File ".../vc_infer_pipeline.py", line 174, in get_f0
    f0_coarse = np.rint(f0_mel).astype(np.int)
  File "/opt/homebrew/lib/python3.8/site-packages/numpy/__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

**[[info](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations)]**

Note: `numpy.int32` should be backwards compatible. [based on e.g. [1.19 docs](https://numpy.org/doc/1.19/reference/arrays.scalars.html#built-in-scalar-types)]


