### PR TITLE
File for detecting i18n missing keys

### DIFF
--- a/scan_i18n.py
+++ b/scan_i18n.py
@@ -1,0 +1,68 @@
+import ast
+import glob
+import json
+
+from collections import OrderedDict
+
+def extract_i18n_strings(node):
+    i18n_strings = []
+
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "i18n":
+        for arg in node.args:
+            if isinstance(arg, ast.Str):
+                i18n_strings.append(arg.s)
+
+    for child_node in ast.iter_child_nodes(node):
+        i18n_strings.extend(extract_i18n_strings(child_node))
+
+    return i18n_strings
+
+# scan the directory for all .py files (recursively)
+# for each file, parse the code into an AST
+# for each AST, extract the i18n strings
+
+strings = []
+for filename in glob.iglob('**/*.py', recursive=True):
+    with open(filename, 'r') as f:
+        code = f.read()
+        if "I18nAuto" in code:
+            tree = ast.parse(code)
+            i18n_strings = extract_i18n_strings(tree)
+            print(filename, len(i18n_strings))
+            strings.extend(i18n_strings)
+code_keys = set(strings)
+'''
+n_i18n.py
+gui_v1.py 26
+app.py 16
+infer-web.py 147
+scan_i18n.py 0
+i18n.py 0
+lib/train/process_ckpt.py 1
+'''
+print()
+print('Total unique:', len(code_keys))
+
+
+
+standard_file = "zh_CN.json"
+with open(f"lib/i18n/{standard_file}", "r", encoding="utf-8") as f:
+    standard_data = json.load(f, object_pairs_hook=OrderedDict)
+standard_keys = set(standard_data.keys())
+
+# Define the standard file name
+unused_keys = standard_keys - code_keys
+print('Unused keys:', len(unused_keys))
+for unused_key in unused_keys:
+    print('\t', unused_key)
+
+missing_keys = code_keys - standard_keys
+print('Missing keys:', len(missing_keys))
+for missing_key in missing_keys:
+    print('\t', missing_key)
+
+
+
+
+
+


### PR DESCRIPTION
While using the web interface in english mode,
I saw a untranslated text:
![image](https://github.com/RVC-Project/Retrieval-based-Voice-Conversion-WebUI/assets/25162836/c5012bd1-ab12-4a09-a2ed-82a6303978ea)

By diving into the code, I saw that some keys are unused (present in lib/i18n/zh_CN.json but not used in the code base) 
and more importantly, some keys are used in the code but not present in lib/i18n/zh_CN.json).

For that, I added the file scan_i18n.py.
When launched (python scan_i18n.py), it display the following:

```
gui_v1.py 26
app.py 16
infer-web.py 147
scan_i18n.py 0
i18n.py 0
lib/train/process_ckpt.py 1

Total unique: 123
Unused keys: 10
         点击查看交流、问题反馈群号
         hubert模型路径不可包含中文
         招募音高曲线前端编辑器
         xxxxx
         也可批量拖拽音频文件, 二选一, 优先读文件夹，文件夹留空则读取拖拽文件
         选择音高提取算法:输入歌声可用pm提速,高质量语音但CPU差可用dio提速,harvest质量更好但慢
         加开发群联系我xxxxx
         Hubert模型
         选择.npy文件
         特征文件路径
Missing keys: 3
         选择音高提取算法,输入歌声可用pm提速,harvest低音好但巨慢无比,crepe效果好但吃GPU
         也可批量输入音频文件, 二选一, 优先读文件夹
         选择音高提取算法:输入歌声可用pm提速,高质量语音但CPU差可用dio提速,harvest质量更好但慢,rmvpe效果最好且微吃CPU/GP
``` 

We can see that   "也可批量输入音频文件, 二选一, 优先读文件夹" is not present while
a very similar key "也可批量拖拽音频文件, 二选一, 优先读文件夹，文件夹留空则读取拖拽文件" is not used. 

I have a hunch that there might have been changes made in the code, but these alterations haven't been mirrored in the JSON file. I'm optimistic that this tool will prove to be valuable in promptly identifying such errors.
I also think that it can be further integrated into the github/actions pipeline to auto-detect this on each commit.