### PR TITLE
fix: logger wrong call

### DIFF
--- a/configs/config.py
+++ b/configs/config.py
@@ -114,11 +114,11 @@ class Config:
                 or "1070" in self.gpu_name
                 or "1080" in self.gpu_name
             ):
-                logger.info("Found GPU", self.gpu_name, ", force to fp32")
+                logger.info("Found GPU %s, force to fp32", self.gpu_name)
                 self.is_half = False
                 use_fp32_config()
             else:
-                logger.info("Found GPU", self.gpu_name)
+                logger.info("Found GPU %s", self.gpu_name)
             self.gpu_mem = int(
                 torch.cuda.get_device_properties(i_device).total_memory
                 / 1024

--- a/tools/rvc_for_realtime.py
+++ b/tools/rvc_for_realtime.py
@@ -341,5 +341,5 @@ class RVC:
                     .float()
                 )
         t5 = ttime()
-        logger.info("Spent time: fea =", t2 - t1, ", index =", t3 - t2, ", f0 =", t4 - t3, ", model =", t5 - t4)
+        logger.info("Spent time: fea = %s, index = %s, f0 = %s, model = %s", t2 - t1, t3 - t2, t4 - t3, t5 - t4)
         return infered_audio


### PR DESCRIPTION
# Pull request checklist

- [x] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [x] Make sure you are requesting the right branch.
- [x] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [x] Ensure all tests are passing.
- [x] Ensure linting is passing.

# PR type

- Bug fix

# Description

- Describe what this pull request is for.
- What will it affect.
If not fix, will log error.
> --- Logging error ---
Traceback (most recent call last):
File "logging_init_.py", line 1100, in emit
File "logging_init_.py", line 943, in format
File "logging_init_.py", line 678, in format
File "logging_init_.py", line 368, in getMessage
TypeError: not all arguments converted during string formatting
Call stack:
File "F:\Retrieval-based-Voice-Conversion-WebUI\gui_v1.py", line 60, in <module>
import tools.rvc_for_realtime as rvc_for_realtime
File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
File "<frozen importlib.bootstrap>", line 688, in load_unlocked
File "<frozen importlib.bootstrap_external>", line 883, in exec_module
File "<frozen importlib.bootstrap>", line 241, in call_with_frames_removed
File "F:\Retrieval-based-Voice-Conversion-WebUI\tools\rvc_for_realtime.py", line 33, in <module>
config = Config()
File "F:\Retrieval-based-Voice-Conversion-WebUI\configs\config.py", line 34, in wrapper
wrapper.instance = func(*args, **kwargs)
File "F:\Retrieval-based-Voice-Conversion-WebUI\configs\config.py", line 58, in init
self.x_pad, self.x_query, self.x_center, self.x_max = self.device_config()
File "F:\Retrieval-based-Voice-Conversion-WebUI\configs\config.py", line 121, in device_config
[logger.info](http://logger.info/)("Found GPU", self.gpu_name)
File "logging_init.py", line 1477, in info
File "logging_init.py", line 1624, in log
File "logging_init.py", line 1634, in handle
File "logging_init.py", line 1696, in callHandlers
File "logging_init.py", line 968, in handle
File "logging_init.py", line 1108, in emit

# Screenshot

- Please include a screenshot if applicable

# Localhost url to test on

- Please include a url on localhost to test.

# Jira Link

- Please include a link to the ticket if applicable.

[Ticket]()
