### PR TITLE
fix gui_v1 set_devices

### DIFF
--- a/gui_v1.py
+++ b/gui_v1.py
@@ -699,10 +699,10 @@ if __name__ == "__main__":
                 output_devices.index(output_device)
             ]
             logger.info(
-                "Input device: %s:%d", str(sd.default.device[0]), input_device
+                "Input device: %s:%s", str(sd.default.device[0]), input_device
             )
             logger.info(
-                "Output device: %s:%d", str(sd.default.device[1]), output_device
+                "Output device: %s:%s", str(sd.default.device[1]), output_device
             )
 
     gui = GUI()


### PR DESCRIPTION
fix print Input device and Output device bug

the format placeholders %d are expecting real numbers (integers or floats), but string values are being passed instead.

By changing %d to %s, you ensure that the argument types match the placeholders in the formatting strings, resolving the error.