### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ WORKDIR /app
 
 COPY . .
 
-RUN apt update && apt install -y -qq ffmpeg aria2
+RUN apt update && apt install -y -qq ffmpeg aria2 && apt clean
 
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 RUN aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/pretrained_v2/D40k.pth -d assets/pretrained_v2/ -o D40k.pth
 RUN aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/pretrained_v2/G40k.pth -d assets/pretrained_v2/ -o G40k.pth


### PR DESCRIPTION
删除Docker镜像构建时的安装缓存以及禁用Python依赖安装时的缓存。可以降低最终镜像大小