### PR TITLE
fix: multiple calls to vc_single now won't cause high pitch clones when resampling

### DIFF
--- a/infer/modules/vc/modules.py
+++ b/infer/modules/vc/modules.py
@@ -209,7 +209,9 @@ class VC:
                 f0_file,
             )
             if self.tgt_sr != resample_sr >= 16000:
-                self.tgt_sr = resample_sr
+                tgt_sr = resample_sr
+            else:
+                tgt_sr = self.tgt_sr
             index_info = (
                 "Index:\n%s." % file_index
                 if os.path.exists(file_index)
@@ -218,7 +220,7 @@ class VC:
             return (
                 "Success.\n%s\nTime:\nnpy: %.2fs, f0: %.2fs, infer: %.2fs."
                 % (index_info, *times),
-                (self.tgt_sr, audio_opt),
+                (tgt_sr, audio_opt),
             )
         except:
             info = traceback.format_exc()


### PR DESCRIPTION
# Pull request checklist

- [ x ] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [ x ] Make sure you are requesting the right branch.
- [ x ] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [ ? ] Ensure all tests are passing.
I did manual testing with known broken examples and tested with and without resampling rates and even models trained on 48000 initially.
- [ x ] Ensure linting is passing.

# PR type

- Bug fix

# Description
Fixes #1233.  The vc_single method was changing the self.tgt_sr which would cause a second call to vc_single to fail to resample if the resample rate was different than the original model.  This would result in the subsequent calls to play back at a higher pitch.
