### PR TITLE
fix: typo for rmvpe location in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co
 
 RUN aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/hubert_base.pt -d assets/hubert -o hubert_base.pt
 
-RUN aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/rmvpe.pt -d assets/hubert -o rmvpe.pt
+RUN aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/rmvpe.pt -d assets/rmvpe -o rmvpe.pt
 
 VOLUME [ "/app/weights", "/app/opt" ]
 


### PR DESCRIPTION
# Pull request checklist

- [x] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [x] Make sure you are requesting the right branch.
- [x] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [x] Ensure all tests are passing.
- [x] Ensure linting is passing.

# PR type

- Bug fix

# Description

- Fixed a typo in the Dockerfile that saved the rmvpe checkpoint into the wrong folder
