### PR TITLE
Fix onnx conversion

### DIFF
--- a/infer-web.py
+++ b/infer-web.py
@@ -165,10 +165,10 @@ def clean():
     return {"value": "", "__type__": "update"}
 
 
-def export_onnx():
+def export_onnx(ModelPath, ExportedPath):
     from infer.modules.onnx.export import export_onnx as eo
 
-    eo()
+    eo(ModelPath, ExportedPath)
 
 
 sr_dict = {

--- a/infer/lib/infer_pack/models_onnx.py
+++ b/infer/lib/infer_pack/models_onnx.py
@@ -622,9 +622,9 @@ class SynthesizerTrnMsNSFsidM(nn.Module):
         self.speaker_map = None
         logger.debug(
             "gin_channels: "
-            + gin_channels
+            + str(gin_channels)
             + ", self.spk_embed_dim: "
-            + self.spk_embed_dim
+            + str(self.spk_embed_dim)
         )
 
     def remove_weight_norm(self):

--- a/requirements-amd.txt
+++ b/requirements-amd.txt
@@ -39,6 +39,7 @@ uvicorn>=0.21.1
 colorama>=0.4.5
 pyworld==0.3.2
 httpx
+onnx==1.14.1
 onnxruntime
 onnxruntime-gpu
 torchcrepe==0.0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ uvicorn>=0.21.1
 colorama>=0.4.5
 pyworld==0.3.2
 httpx
+onnx==1.14.1
 onnxruntime; sys_platform == 'darwin'
 onnxruntime-gpu; sys_platform != 'darwin'
 torchcrepe==0.0.20


### PR DESCRIPTION
Lightly tested on CPU and my AMD RX 7800XT, this fixes the chain of minor issues preventing ONNX conversion for models, and the requirements files as well (since there are now **three** required onnx modules, as one was omitted that was required for conversion.)