### PR TITLE
Update infer-web.py

### DIFF
--- a/infer-web.py
+++ b/infer-web.py
@@ -44,6 +44,9 @@ os.makedirs(tmp, exist_ok=True)
 os.makedirs(os.path.join(now_dir, "logs"), exist_ok=True)
 os.makedirs(os.path.join(now_dir, "assets/weights"), exist_ok=True)
 os.environ["TEMP"] = tmp
+os.environ['PATH'] += os.pathsep + os.path.join(now_dir, 'ffmpeg')
+os.environ['PATH'] += os.pathsep + os.path.join(now_dir, 'ffprobe')
+
 warnings.filterwarnings("ignore")
 torch.manual_seed(114514)
 


### PR DESCRIPTION
I added the paths for FFmpeg and ffprobe to resolve the "ffmpeg not a command" error that occurred when running Infer-Web for audio source separation.

`os.environ['PATH'] += os.pathsep + os.path.join(now_dir, 'ffmpeg')
`
`os.environ['PATH'] += os.pathsep + os.path.join(now_dir, 'ffprobe')`

# Pull request checklist

- [ ] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [ ] Make sure you are requesting the right branch: `dev`.
- [ ] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [ ] Ensure all tests are passing.
- [ ] Ensure linting is passing.

# PR type

- Bug fix / new feature / chore

# Description

- Describe what this pull request is for.
- What will it affect.

# Screenshot

- Please include a screenshot if applicable

# Localhost url to test on

- Please include a url on localhost to test.

# Jira Link

- Please include a link to the ticket if applicable.

[Ticket]()
