### PR TITLE
fix: Resolve CLI errors due to None value in index file path

### DIFF
--- a/infer/modules/vc/modules.py
+++ b/infer/modules/vc/modules.py
@@ -169,18 +169,17 @@ class VC:
             if self.hubert_model is None:
                 self.hubert_model = load_hubert(self.config)
 
-            file_index = (
-                (
-                    file_index.strip(" ")
-                    .strip('"')
-                    .strip("\n")
-                    .strip('"')
-                    .strip(" ")
-                    .replace("trained", "added")
-                )
-                if file_index != ""
-                else file_index2
-            )  # 防止小白写错，自动帮他替换掉
+            if file_index:
+                file_index = file_index.strip(" ") \
+                .strip('"') \
+                .strip("\n") \
+                .strip('"') \
+                .strip(" ") \
+                .replace("trained", "added")
+            elif file_index2:
+                file_index = file_index2
+            else:
+                file_index = "" # 防止小白写错，自动帮他替换掉
 
             audio_opt = self.pipeline.pipeline(
                 self.hubert_model,


### PR DESCRIPTION

- [x] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [x] Make sure you are requesting the right branch: `dev`.
- [x] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [x] Ensure all tests are passing.
- [x] Ensure linting is passing.

# PR type

- Bug fix

# Description

If the `file_index` parameter is `None`, an error is raised when `strip()` is executed on it. Additionally, a `None` value leads to a type error in the subsequent pipeline call
`TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType`

This PR reorders the conditional check to restore the intended behavior of defaulting to `file_index2`'s value if `file_index` is not defined. If neither `file_index` nor `file_index2` are defined, it is set to `""` to prevent the TypeError above

This change does not create any side effects on the web UI
# How to reproduce

Run `infer_cli.py` or `infer_batch_rvc.py` with all arguments except `index_path`

