### PR TITLE
Added support for L4&RTX6000 GPU in WebUI

### DIFF
--- a/infer-web.py
+++ b/infer-web.py
@@ -93,6 +93,7 @@ if torch.cuda.is_available() or ngpu != 0:
                 "M4",
                 "T4",
                 "TITAN",
+                "L4",
             ]
         ):
             # A10#A100#V100#A40#P40#M40#K80#A4500

--- a/infer-web.py
+++ b/infer-web.py
@@ -94,6 +94,7 @@ if torch.cuda.is_available() or ngpu != 0:
                 "T4",
                 "TITAN",
                 "L4",
+                "6000",
             ]
         ):
             # A10#A100#V100#A40#P40#M40#K80#A4500


### PR DESCRIPTION
# PR type

- chore

# Description

- We made changes to "infer-web.py" because the WebUI did not recognize L4&RTX 6000 GPUs.
- These changes will allow the WebUI to correctly recognize L4&RTX 6000 GPUs and use them without any problems.