### PR TITLE
Specify numpy version at requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 joblib>=1.1.0
 numba
-numpy
+numpy==1.23.5
 scipy
 librosa==0.9.1
 llvmlite


### PR DESCRIPTION
# PR type
Bug fix

# Description
Since numpy 1.24.0, the float attribute has been removed (Refer to the [update log](https://numpy.org/doc/stable/release/1.24.0-notes.html)).
Due to the update, vc-webui inference doesn't work with the error "module 'numpy' has no attribute float" when the user has created an environment using requirements.txt

To avoid this issue, I specified the numpy version as 1.23.5 at requirement.txt, which has a float attribute, as shown in other requirements files (e.g., requirements-amd, requirements-dml)