### PR TITLE
fix: ValueError: mode must be 'r', 'w', or None, got: wb

### DIFF
--- a/infer/lib/audio.py
+++ b/infer/lib/audio.py
@@ -5,10 +5,10 @@ import av
 
 
 def wav2(i, o, format):
-    inp = av.open(i, "rb")
+    inp = av.open(i, "r")
     if format == "m4a":
         format = "mp4"
-    out = av.open(o, "wb", format=format)
+    out = av.open(o, "w", format=format)
     if format == "ogg":
         format = "libvorbis"
     if format == "mp4":


### PR DESCRIPTION
On some computers the "wb" function could cause errors. At the moment I only saw it happen during the previous phases of the training so I only modified that.


**Error sample:**
```Traceback (most recent call last):
  File "infer/modules/train/preprocess.py", line 87, in pipeline
    audio = load_audio(path, self.sr)
  File "/home/user/Desktop/RVC1006Nvidia/infer/lib/audio.py", line 73, in load_audio
    raise RuntimeError(traceback.format_exc())
RuntimeError: Traceback (most recent call last):
  File "/home/user/Desktop/RVC1006Nvidia/infer/lib/audio.py", line 63, in load_audio
    audio2(f, out, "f32le", sr)
  File "/home/user/Desktop/RVC1006Nvidia/infer/lib/audio.py", line 35, in audio2
    out = av.open(o, "wb", format=format)
  File "av/container/core.pyx", line 398, in av.container.core.open
ValueError: mode must be 'r', 'w', or None, got: wb
```