### PR TITLE
fix: Correct Python installation check and download success check logic

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -14,7 +14,7 @@ else
   requirements_file="requirements.txt"
 
   # Check if Python 3.8 is installed
-  if ! command -v python3.8 >/dev/null 2>&1 || pyenv versions --bare | grep -q "3.8"; then
+  if ! (command -v python3.8 >/dev/null 2>&1 || pyenv versions --bare | grep -q "3.8"); then
     echo "Python 3 not found. Attempting to install 3.8..."
     if [ "$(uname)" = "Darwin" ] && command -v brew >/dev/null 2>&1; then
       brew install python@3.8

--- a/tools/dlmodels.sh
+++ b/tools/dlmodels.sh
@@ -34,7 +34,7 @@ check_file_pretrained() {
       echo failed. starting download from huggingface.
       if command -v aria2c > /dev/null 2>&1; then
           aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/"$1"/"$2" -d ./assets/"$1" -o "$2"
-          [ -f "./assets/""$1""/""$2""" ] && echo "download successful." || echo "please try again!" && exit 1
+          [ -f "./assets/""$1""/""$2""" ] && echo "download successful." || (echo "please try again!" && exit 1)
       else
           echo "aria2c command not found. Please install aria2c and try again."
           exit 1
@@ -50,7 +50,7 @@ check_file_special() {
       echo failed. starting download from huggingface.
       if command -v aria2c > /dev/null 2>&1; then
           aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/"$2" -d ./assets/"$1" -o "$2"
-          [ -f "./assets/""$1""/""$2""" ] && echo "download successful." || echo "please try again!" && exit 1
+          [ -f "./assets/""$1""/""$2""" ] && echo "download successful." || (echo "please try again!" && exit 1)
       else
           echo "aria2c command not found. Please install aria2c and try again."
           exit 1


### PR DESCRIPTION
# Pull request checklist

- [x] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [x] Make sure you are requesting the right branch: `dev`.
- [x] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [x] Ensure all tests are passing.
- [x] Ensure linting is passing.

# PR type

- Bug fix

# Description

This pull request addresses two issues in the shell script:

1. **Fix Python installation check logic (Issue #2073)**:
   - The script was always downloading Python even if it was already installed via `pyenv`.
   - The condition has been corrected to properly check if `python3.8` is available or if `pyenv` has `3.8` installed.

2. **Fix download success check logic (Issue #2074)**:
   - The script was incorrectly exiting after a successful download, preventing subsequent downloads.
   - The logic has been corrected to ensure that the script continues to download files after a successful download and only exits after a failure.

# Screenshot

- Not applicable
