### PR TITLE
fix: Updated librosa to version 0.10.2

### DIFF
--- a/infer/lib/uvr5_pack/lib_v5/spec_utils.py
+++ b/infer/lib/uvr5_pack/lib_v5/spec_utils.py
@@ -43,8 +43,8 @@ def wave_to_spectrogram(
         wave_left = np.asfortranarray(wave[0])
         wave_right = np.asfortranarray(wave[1])
 
-    spec_left = librosa.stft(wave_left, n_fft, hop_length=hop_length)
-    spec_right = librosa.stft(wave_right, n_fft, hop_length=hop_length)
+    spec_left = librosa.stft(wave_left, n_fft=n_fft, hop_length=hop_length)
+    spec_right = librosa.stft(wave_right, n_fft=n_fft, hop_length=hop_length)
 
     spec = np.asfortranarray([spec_left, spec_right])
 
@@ -78,7 +78,7 @@ def wave_to_spectrogram_mt(
         kwargs={"y": wave_left, "n_fft": n_fft, "hop_length": hop_length},
     )
     thread.start()
-    spec_right = librosa.stft(wave_right, n_fft, hop_length=hop_length)
+    spec_right = librosa.stft(wave_right, n_fft=n_fft, hop_length=hop_length)
     thread.join()
 
     spec = np.asfortranarray([spec_left, spec_right])
@@ -230,26 +230,30 @@ def cache_or_load(mix_path, inst_path, mp):
 
             if d == len(mp.param["band"]):  # high-end band
                 X_wave[d], _ = librosa.load(
-                    mix_path, bp["sr"], False, dtype=np.float32, res_type=bp["res_type"]
+                    mix_path,
+                    sr=bp["sr"],
+                    mono=False,
+                    dtype=np.float32,
+                    res_type=bp["res_type"]
                 )
                 y_wave[d], _ = librosa.load(
                     inst_path,
-                    bp["sr"],
-                    False,
+                    sr=bp["sr"],
+                    mono=False,
                     dtype=np.float32,
                     res_type=bp["res_type"],
                 )
             else:  # lower bands
                 X_wave[d] = librosa.resample(
                     X_wave[d + 1],
-                    mp.param["band"][d + 1]["sr"],
-                    bp["sr"],
+                    orig_sr=mp.param["band"][d + 1]["sr"],
+                    target_sr=bp["sr"],
                     res_type=bp["res_type"],
                 )
                 y_wave[d] = librosa.resample(
                     y_wave[d + 1],
-                    mp.param["band"][d + 1]["sr"],
-                    bp["sr"],
+                    orig_sr=mp.param["band"][d + 1]["sr"],
+                    target_sr=bp["sr"],
                     res_type=bp["res_type"],
                 )
 
@@ -401,8 +405,8 @@ def cmb_spectrogram_to_wave(spec_m, mp, extra_bins_h=None, extra_bins=None):
                         mp.param["mid_side_b2"],
                         mp.param["reverse"],
                     ),
-                    bp["sr"],
-                    sr,
+                    orig_sr=bp["sr"],
+                    target_sr=sr,
                     res_type="sinc_fastest",
                 )
             else:  # mid
@@ -419,7 +423,7 @@ def cmb_spectrogram_to_wave(spec_m, mp, extra_bins_h=None, extra_bins=None):
                     ),
                 )
                 # wave = librosa.core.resample(wave2, bp['sr'], sr, res_type="sinc_fastest")
-                wave = librosa.core.resample(wave2, bp["sr"], sr, res_type="scipy")
+                wave = librosa.resample(wave2, orig_sr=bp["sr"], target_sr=sr, res_type="scipy")
 
     return wave.T
 
@@ -506,8 +510,8 @@ def ensembling(a, specs):
 def stft(wave, nfft, hl):
     wave_left = np.asfortranarray(wave[0])
     wave_right = np.asfortranarray(wave[1])
-    spec_left = librosa.stft(wave_left, nfft, hop_length=hl)
-    spec_right = librosa.stft(wave_right, nfft, hop_length=hl)
+    spec_left = librosa.stft(wave_left, n_fft=nfft, hop_length=hl)
+    spec_right = librosa.stft(wave_right, n_fft=nfft, hop_length=hl)
     spec = np.asfortranarray([spec_left, spec_right])
 
     return spec
@@ -569,8 +573,8 @@ if __name__ == "__main__":
             if d == len(mp.param["band"]):  # high-end band
                 wave[d], _ = librosa.load(
                     args.input[i],
-                    bp["sr"],
-                    False,
+                    sr=bp["sr"],
+                    mono=False,
                     dtype=np.float32,
                     res_type=bp["res_type"],
                 )
@@ -580,8 +584,8 @@ if __name__ == "__main__":
             else:  # lower bands
                 wave[d] = librosa.resample(
                     wave[d + 1],
-                    mp.param["band"][d + 1]["sr"],
-                    bp["sr"],
+                    orig_sr=mp.param["band"][d + 1]["sr"],
+                    target_sr=bp["sr"],
                     res_type=bp["res_type"],
                 )
 

--- a/infer/modules/uvr5/vr.py
+++ b/infer/modules/uvr5/vr.py
@@ -60,20 +60,20 @@ class AudioPre:
                 (
                     X_wave[d],
                     _,
-                ) = librosa.core.load(  # 理论上librosa读取可能对某些音频有bug，应该上ffmpeg读取，但是太麻烦了弃坑
+                ) = librosa.load(  # 理论上librosa读取可能对某些音频有bug，应该上ffmpeg读取，但是太麻烦了弃坑
                     music_file,
-                    bp["sr"],
-                    False,
+                    sr=bp["sr"],
+                    mono=False,
                     dtype=np.float32,
                     res_type=bp["res_type"],
                 )
                 if X_wave[d].ndim == 1:
                     X_wave[d] = np.asfortranarray([X_wave[d], X_wave[d]])
             else:  # lower bands
-                X_wave[d] = librosa.core.resample(
+                X_wave[d] = librosa.resample(
                     X_wave[d + 1],
-                    self.mp.param["band"][d + 1]["sr"],
-                    bp["sr"],
+                    orig_sr=self.mp.param["band"][d + 1]["sr"],
+                    target_sr=bp["sr"],
                     res_type=bp["res_type"],
                 )
             # Stft of wave source
@@ -241,20 +241,20 @@ class AudioPreDeEcho:
                 (
                     X_wave[d],
                     _,
-                ) = librosa.core.load(  # 理论上librosa读取可能对某些音频有bug，应该上ffmpeg读取，但是太麻烦了弃坑
+                ) = librosa.load(  # 理论上librosa读取可能对某些音频有bug，应该上ffmpeg读取，但是太麻烦了弃坑
                     music_file,
-                    bp["sr"],
-                    False,
+                    sr=bp["sr"],
+                    mono=False,
                     dtype=np.float32,
                     res_type=bp["res_type"],
                 )
                 if X_wave[d].ndim == 1:
                     X_wave[d] = np.asfortranarray([X_wave[d], X_wave[d]])
             else:  # lower bands
-                X_wave[d] = librosa.core.resample(
+                X_wave[d] = librosa.resample(
                     X_wave[d + 1],
-                    self.mp.param["band"][d + 1]["sr"],
-                    bp["sr"],
+                    orig_sr=self.mp.param["band"][d + 1]["sr"],
+                    target_sr=bp["sr"],
                     res_type=bp["res_type"],
                 )
             # Stft of wave source

--- a/requirements-amd.txt
+++ b/requirements-amd.txt
@@ -3,7 +3,7 @@ joblib>=1.1.0
 numba==0.56.4
 numpy==1.23.5
 scipy
-librosa==0.9.1
+librosa==0.10.2
 llvmlite==0.39.0
 fairseq==0.12.2
 faiss-cpu==1.7.3
@@ -41,7 +41,7 @@ pyworld==0.3.2
 httpx
 onnxruntime
 onnxruntime-gpu
-torchcrepe==0.0.20
+torchcrepe==0.0.23
 fastapi==0.88
 ffmpy==0.3.1
 python-dotenv>=1.0.0

--- a/requirements-dml.txt
+++ b/requirements-dml.txt
@@ -2,7 +2,7 @@ joblib>=1.1.0
 numba==0.56.4
 numpy==1.23.5
 scipy
-librosa==0.9.1
+librosa==0.10.2
 llvmlite==0.39.0
 fairseq==0.12.2
 faiss-cpu==1.7.3
@@ -39,7 +39,7 @@ colorama>=0.4.5
 pyworld==0.3.2
 httpx
 onnxruntime-directml
-torchcrepe==0.0.20
+torchcrepe==0.0.23
 fastapi==0.88
 ffmpy==0.3.1
 python-dotenv>=1.0.0

--- a/requirements-ipex.txt
+++ b/requirements-ipex.txt
@@ -7,7 +7,7 @@ joblib>=1.1.0
 numba==0.56.4
 numpy==1.23.5
 scipy
-librosa==0.9.1
+librosa==0.10.2
 llvmlite==0.39.0
 fairseq==0.12.2
 faiss-cpu==1.7.3
@@ -45,7 +45,7 @@ pyworld==0.3.2
 httpx
 onnxruntime; sys_platform == 'darwin'
 onnxruntime-gpu; sys_platform != 'darwin'
-torchcrepe==0.0.20
+torchcrepe==0.0.23
 fastapi==0.88
 ffmpy==0.3.1
 python-dotenv>=1.0.0

--- a/requirements-py311.txt
+++ b/requirements-py311.txt
@@ -2,7 +2,7 @@ joblib>=1.1.0
 numba
 numpy
 scipy
-librosa==0.9.1
+librosa==0.10.2
 llvmlite
 fairseq @ git+https://github.com/One-sixth/fairseq.git
 faiss-cpu
@@ -40,7 +40,7 @@ pyworld==0.3.2
 httpx
 onnxruntime; sys_platform == 'darwin'
 onnxruntime-gpu; sys_platform != 'darwin'
-torchcrepe==0.0.20
+torchcrepe==0.0.23
 fastapi==0.88
 torchfcpe
 ffmpy==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ joblib>=1.1.0
 numba
 numpy
 scipy
-librosa==0.9.1
+librosa==0.10.2
 llvmlite
 fairseq
 faiss-cpu
@@ -40,7 +40,7 @@ pyworld==0.3.2
 httpx
 onnxruntime; sys_platform == 'darwin'
 onnxruntime-gpu; sys_platform != 'darwin'
-torchcrepe==0.0.20
+torchcrepe==0.0.23
 fastapi==0.88
 torchfcpe
 ffmpy==0.3.1


### PR DESCRIPTION
# Pull request checklist

- [x] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [x] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [x] Ensure you can run the codes you submitted succesfully. These submissions will be prioritized for review:

    Introduce improvements in program execution speed;

    Introduce improvements in synthesis quality;

    Fix existing bugs reported by user feedback (or you met);

    Introduce more convenient user operations.

# PR type

- Bug fix

# Description

There is a bug in librosa 0.9.1.
https://github.com/librosa/librosa/pull/1594

As a result, an error occurs when executing the "Vocals/Accompaniment Separation & Reverberation Removal" function.

## Error log
```
xxx.mp3.reformatted.wav->Traceback (most recent call last):
  File "/workspace/Retrieval-based-Voice-Conversion-WebUI/infer/modules/uvr5/modules.py", line 74, in uvr
    pre_fun._path_audio_(
  File "/workspace/Retrieval-based-Voice-Conversion-WebUI/infer/modules/uvr5/vr.py", line 119, in _path_audio_
    wav_instrument = spec_utils.cmb_spectrogram_to_wave(
  File "/workspace/Retrieval-based-Voice-Conversion-WebUI/infer/lib/uvr5_pack/lib_v5/spec_utils.py", line 397, in cmb_spectrogram_to_wave
    spectrogram_to_wave(
  File "/workspace/Retrieval-based-Voice-Conversion-WebUI/infer/lib/uvr5_pack/lib_v5/spec_utils.py", line 295, in spectrogram_to_wave
    wave_left = librosa.istft(spec_left, hop_length=hop_length)
  File "/workspace/Retrieval-based-Voice-Conversion-WebUI/venv/lib/python3.10/site-packages/librosa/util/decorators.py", line 88, in inner_f
    return f(*args, **kwargs)
  File "/workspace/Retrieval-based-Voice-Conversion-WebUI/venv/lib/python3.10/site-packages/librosa/core/spectrum.py", line 394, in istft
    dtype = util.dtype_c2r(stft_matrix.dtype)
  File "/workspace/Retrieval-based-Voice-Conversion-WebUI/venv/lib/python3.10/site-packages/librosa/util/decorators.py", line 88, in inner_f
    return f(*args, **kwargs)
  File "/workspace/Retrieval-based-Voice-Conversion-WebUI/venv/lib/python3.10/site-packages/librosa/util/utils.py", line 2185, in dtype_c2r
    np.dtype(complex): np.dtype(np.float).type,
  File "/workspace/Retrieval-based-Voice-Conversion-WebUI/venv/lib/python3.10/site-packages/numpy/__init__.py", line 324, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'cfloat'?
```

To address this issue, librosa has been upgraded to version 0.10.2.
Additionally, torchcrepe has been upgraded due to its dependency on librosa.
