### PR TITLE
fix: dlmodels.sh exits after download single file

### DIFF
--- a/tools/dlmodels.sh
+++ b/tools/dlmodels.sh
@@ -34,7 +34,7 @@ check_file_pretrained() {
       echo failed. starting download from huggingface.
       if command -v aria2c > /dev/null 2>&1; then
           aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/"$1"/"$2" -d ./assets/"$1" -o "$2"
-          [ -f "./assets/""$1""/""$2""" ] && echo "download successful." || echo "please try again!" && exit 1
+          [ -f "./assets/""$1""/""$2""" ] && echo "download successful." || { echo "please try again!" && exit 1; }
       else
           echo "aria2c command not found. Please install aria2c and try again."
           exit 1
@@ -50,7 +50,7 @@ check_file_special() {
       echo failed. starting download from huggingface.
       if command -v aria2c > /dev/null 2>&1; then
           aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/"$2" -d ./assets/"$1" -o "$2"
-          [ -f "./assets/""$1""/""$2""" ] && echo "download successful." || echo "please try again!" && exit 1
+          [ -f "./assets/""$1""/""$2""" ] && echo "download successful." || { echo "please try again!" && exit 1; }
       else
           echo "aria2c command not found. Please install aria2c and try again."
           exit 1


### PR DESCRIPTION
# Pull request checklist

- [x] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [x] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [x] Ensure you can run the codes you submitted succesfully. These submissions will be prioritized for review:

    Introduce improvements in program execution speed;

    Introduce improvements in synthesis quality;

    Fix existing bugs reported by user feedback (or you met);

    Introduce more convenient user operations.

# PR type

- Bug fix
# Description

- This pull request fixes a bug in dlmodels.sh that caused it to exit after downloading a single file.
- Improves the script's reliability by allowing multiple sequential downloads without interruption.

# Screenshot

![image](https://github.com/RVC-Project/Retrieval-based-Voice-Conversion-WebUI/assets/74850890/039557fe-a95b-4000-9a50-00832c24dd37)
