### PR TITLE
fix: allow path name contains special characters

### DIFF
--- a/infer/modules/uvr5/mdxnet.py
+++ b/infer/modules/uvr5/mdxnet.py
@@ -220,7 +220,7 @@ class Predictor:
             opt_path_other = path_other[:-4] + ".%s" % format
             if os.path.exists(path_vocal):
                 os.system(
-                    "ffmpeg -i %s -vn %s -q:a 2 -y" % (path_vocal, opt_path_vocal)
+                    'ffmpeg -i "%s" -vn "%s" -q:a 2 -y' % (path_vocal, opt_path_vocal)
                 )
                 if os.path.exists(opt_path_vocal):
                     try:
@@ -229,7 +229,7 @@ class Predictor:
                         pass
             if os.path.exists(path_other):
                 os.system(
-                    "ffmpeg -i %s -vn %s -q:a 2 -y" % (path_other, opt_path_other)
+                    'ffmpeg -i "%s" -vn "%s" -q:a 2 -y' % (path_other, opt_path_other)
                 )
                 if os.path.exists(opt_path_other):
                     try:

--- a/infer/modules/uvr5/modules.py
+++ b/infer/modules/uvr5/modules.py
@@ -65,7 +65,7 @@ def uvr(model_name, inp_root, save_root_vocal, paths, save_root_ins, agg, format
                     os.path.basename(inp_path),
                 )
                 os.system(
-                    "ffmpeg -i %s -vn -acodec pcm_s16le -ac 2 -ar 44100 %s -y"
+                    'ffmpeg -i "%s" -vn -acodec pcm_s16le -ac 2 -ar 44100 "%s" -y'
                     % (inp_path, tmp_path)
                 )
                 inp_path = tmp_path

--- a/infer/modules/uvr5/vr.py
+++ b/infer/modules/uvr5/vr.py
@@ -146,7 +146,7 @@ class AudioPre:
                 )
                 if os.path.exists(path):
                     opt_format_path = path[:-4] + ".%s" % format
-                    os.system("ffmpeg -i %s -vn %s -q:a 2 -y" % (path, opt_format_path))
+                    os.system('ffmpeg -i "%s" -vn "%s" -q:a 2 -y' % (path, opt_format_path))
                     if os.path.exists(opt_format_path):
                         try:
                             os.remove(path)
@@ -187,7 +187,7 @@ class AudioPre:
                 )
                 if os.path.exists(path):
                     opt_format_path = path[:-4] + ".%s" % format
-                    os.system("ffmpeg -i %s -vn %s -q:a 2 -y" % (path, opt_format_path))
+                    os.system('ffmpeg -i "%s" -vn "%s" -q:a 2 -y' % (path, opt_format_path))
                     if os.path.exists(opt_format_path):
                         try:
                             os.remove(path)
@@ -323,7 +323,7 @@ class AudioPreDeEcho:
                 )
                 if os.path.exists(path):
                     opt_format_path = path[:-4] + ".%s" % format
-                    os.system("ffmpeg -i %s -vn %s -q:a 2 -y" % (path, opt_format_path))
+                    os.system('ffmpeg -i "%s" -vn "%s" -q:a 2 -y' % (path, opt_format_path))
                     if os.path.exists(opt_format_path):
                         try:
                             os.remove(path)
@@ -360,7 +360,7 @@ class AudioPreDeEcho:
                 )
                 if os.path.exists(path):
                     opt_format_path = path[:-4] + ".%s" % format
-                    os.system("ffmpeg -i %s -vn %s -q:a 2 -y" % (path, opt_format_path))
+                    os.system('ffmpeg -i "%s" -vn "%s" -q:a 2 -y' % (path, opt_format_path))
                     if os.path.exists(opt_format_path):
                         try:
                             os.remove(path)


### PR DESCRIPTION
# Pull request checklist

- [x] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [x] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [x] Ensure you can run the codes you submitted succesfully. These submissions will be prioritized for review:

    Introduce improvements in program execution speed;

    Introduce improvements in synthesis quality;

    Fix existing bugs reported by user feedback (or you met);

    Introduce more convenient user operations.

# PR type

- Bug fix

# Description

Allow path name contains special characters.

I've posted this before, see #2052.

I really recommend to use f-string in Python3. But it looks like you don't like others to change your code style.

So I adjust the style to add this feature again.

---

For example Microsoft always uses your account name as the user folder which would contains a space. Music audio file often contains some special characters. And there are also a lot of other cases.

It would really convenient for users if we can support this.
