### PR TITLE
feat+fix: adds compatibility to pyenv and let pyenv install python 3.8 if it's not installed

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -17,13 +17,17 @@ else
   requirements_file="requirements.txt"
 
   # Check if Python 3.8 is installed
-  if ! command -v python3.8 >/dev/null 2>&1 || pyenv versions --bare | grep -q "3.8"; then
+  if ! command -v python3.8 >/dev/null 2>&1 || pyenv versions --bare | grep -qv "3.8"; then
     echo "Python 3 not found. Attempting to install 3.8..."
     if [ "$(uname)" = "Darwin" ] && command -v brew >/dev/null 2>&1; then
       brew install python@3.8
     elif [ "$(uname)" = "Linux" ] && command -v apt-get >/dev/null 2>&1; then
       sudo apt-get update
       sudo apt-get install python3.8
+    elif [ "$(uname)" = "Linux" ] && command -v pyenv >/dev/null 2>&1; then
+      pyenv install 3.8
+      pyenv local 3.8
+      alias python3.8=python
     else
       echo "Please install Python 3.8 manually."
       exit 1


### PR DESCRIPTION
# Pull request checklist

- [x] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [x] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [x] Ensure you can run the codes you submitted succesfully. These submissions will be prioritized for review:

    Introduce improvements in program execution speed;

    Introduce improvements in synthesis quality;

    Fix existing bugs reported by user feedback (or you met);

    Introduce more convenient user operations.

# PR type

- Bug fix / new feature

# Description
updates run.sh to add pyenv compatibility. Pyenv check was not working as intended, it should be inverted match (with -v). if pyenv exists in the system, it will now install python3.8 and set it as the default for the current folder

This should give support to Arch Linux users, among other distros who suggest users to use pyenv.

Review needed, 2 questions:
1. Is it safe to set python3.8 as the default for the current folder? If you don't know and no one can verify, let's assume it is. I think it likely is, but I can't account for every possibility.
2. Which version of python 3.8 do you prefer? If it's not 3.8.19, it should be changed to the one you wish to have installed (like 3.8.0)

# Screenshot

- Please include a screenshot if applicable

not applicable
