### PR TITLE
Fixing bug "concurrency_count has been deprecated issue." when running python infer-web.py

### DIFF
--- a/infer-web.py
+++ b/infer-web.py
@@ -1609,9 +1609,9 @@ with gr.Blocks(title="RVC WebUI") as app:
                 gr.Markdown(traceback.format_exc())
 
     if config.iscolab:
-        app.queue(concurrency_count=511, max_size=1022).launch(share=True)
+        app.queue(max_size=1022).launch(share=True)
     else:
-        app.queue(concurrency_count=511, max_size=1022).launch(
+        app.queue(max_size=1022).launch(
             server_name="0.0.0.0",
             inbrowser=not config.noautoopen,
             server_port=config.listen_port,


### PR DESCRIPTION
# Pull request checklist

- [ ] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [ ] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [ ] Ensure you can run the codes you submitted succesfully. These submissions will be prioritized for review:

    Fix existing bug concurrency_count has been deprecated when running python infer-web.py

# PR type

- Bug fix 

# Description
concurrency_count has been deprecated when running python infer-web.py

# Screenshot
![image](https://github.com/user-attachments/assets/7c3ccaf9-a084-4285-96e9-1fc79f1cf12b)
