### PR TITLE
style: convert single quotes to back quotes 

### DIFF
--- a/docs/jp/README.ja.md
+++ b/docs/jp/README.ja.md
@@ -214,9 +214,9 @@ sudo usermod -aG video $USERNAME
 ### 直接起動
 
 以下のコマンドで WebUI を起動します
-'''bash
+```bash
 python infer-web.py
-'''
+```
 
 ### 統合パッケージの使用
 
@@ -228,15 +228,15 @@ python infer-web.py
 
 #### MacOS ユーザー
 
-'''bash
+```bash
 sh ./run.sh
-'''
+```
 
 ### IPEX 技術が必要な I カードユーザー向け(Linux のみ)
 
-'''bash
+```bash
 source /opt/intel/oneapi/setvars.sh
-'''
+```
 
 ## 参考プロジェクト
 


### PR DESCRIPTION
Close #2232 
This commit changed the single quotes to back quotes where they were used in the Markdown.

# Pull request checklist

- [x] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [x] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [x] Ensure you can run the codes you submitted succesfully. These submissions will be prioritized for review:

# PR type

- Bug fix 
  - (like a typo)

# Description

In the Japanese README, there were some parts where the Markdown format was not correctly written. I corrected the formatting by replacing the single quotes with back quotes.

# Screenshot
- before
![image](https://github.com/user-attachments/assets/abb1d127-5492-438e-85ad-fddbf76e3d0f)

- after
![image](https://github.com/user-attachments/assets/d665bdb6-91cf-469f-a649-5c10a72c3f4c)


