### PR TITLE
fix: resolve inconsistent sample rates and improve Train tab layout

### DIFF
--- a/infer-web.py
+++ b/infer-web.py
@@ -441,9 +441,9 @@ def change_version19(sr2, if_f0_3, version19):
     if sr2 == "32k" and version19 == "v1":
         sr2 = "40k"
     to_return_sr2 = (
-        {"choices": ["40k", "48k"], "__type__": "update", "value": sr2}
+        {"choices": ["32k", "40k", "48k"], "__type__": "update", "value": sr2}
         if version19 == "v1"
-        else {"choices": ["40k", "48k", "32k"], "__type__": "update", "value": sr2}
+        else {"choices": ["32k", "48k"], "__type__": "update", "value": sr2}
     )
     f0_str = "f0" if if_f0_3 else ""
     return (
@@ -1176,10 +1176,17 @@ with gr.Blocks(title="RVC WebUI") as app:
             )
             with gr.Row():
                 exp_dir1 = gr.Textbox(label=i18n("输入实验名"), value="mi-test")
+                version19 = gr.Radio(
+                    label=i18n("版本"),
+                    choices=["v1", "v2"],
+                    value="v2",
+                    interactive=True,
+                    visible=True,
+                )
                 sr2 = gr.Radio(
                     label=i18n("目标采样率"),
-                    choices=["40k", "48k"],
-                    value="40k",
+                    choices=["32k", "48k"],
+                    value="48k",
                     interactive=True,
                 )
                 if_f0_3 = gr.Radio(
@@ -1187,13 +1194,6 @@ with gr.Blocks(title="RVC WebUI") as app:
                     choices=[True, False],
                     value=True,
                     interactive=True,
-                )
-                version19 = gr.Radio(
-                    label=i18n("版本"),
-                    choices=["v1", "v2"],
-                    value="v2",
-                    interactive=True,
-                    visible=True,
                 )
                 np7 = gr.Slider(
                     minimum=0,
@@ -1339,12 +1339,12 @@ with gr.Blocks(title="RVC WebUI") as app:
                 with gr.Row():
                     pretrained_G14 = gr.Textbox(
                         label=i18n("加载预训练底模G路径"),
-                        value="assets/pretrained_v2/f0G40k.pth",
+                        value="assets/pretrained_v2/f0G48k.pth",
                         interactive=True,
                     )
                     pretrained_D15 = gr.Textbox(
                         label=i18n("加载预训练底模D路径"),
-                        value="assets/pretrained_v2/f0D40k.pth",
+                        value="assets/pretrained_v2/f0D48k.pth",
                         interactive=True,
                     )
                     sr2.change(


### PR DESCRIPTION
# Pull request checklist

- [x] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [x] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [x] Ensure you can run the codes you submitted successfully. These submissions will be prioritized for review:
  - Introduce improvements in program execution speed;
  - Introduce improvements in synthesis quality;
  - Fix existing bugs reported by user feedback (or you met);
  - Introduce more convenient user operations.

# PR type

- Bug fix / synthesis quality improvement

# Description

This commit addresses two issues on the Train tab:

1. **Inconsistent Target Sample Rates:**
   - Resolved an issue where switching versions led to inconsistent Target sample rate options. Additionally, I want to point out a missing v2 - 40k configuration file. Despite v2 having a 40k pretrained model:
     - assets/pretrained  (32k, 40k, 48k)
     - assets/pretrained_v2  (32k, 40k, 48k)
     - configs/v1 (32k, 40k, 48k)
     - configs/v2 (32k, 48k)
   - Tests showed that the default settings 40k - v2 generated an incorrect 40k - v1 config file. The default settings have been updated to use 48k - v2 to align the sample rates correctly.

   Now:
   - v1 will consistently show 32k, 40k, and 48k
   - v2 will consistently show 32k and 48k

   **Note:** Ensures that selecting the 40k option for v2 no longer results in an incorrect configuration file.

2. **Repositioned 'Version' Field:**
   - Moved the 'Version' field to appear before the 'Target sample rate' field on the Train tab. This improves the logical flow and user experience by ensuring that the 'Version' selection is made before choosing the 'Target sample rate' it is updating.

   Changes:
   - Updated layout on the Train tab to reposition the 'Version' field.

   **Note:** No functional changes to the data processing were made.