### PR TITLE
移除音频文件路径 Unicode 控制字符

### DIFF
--- a/infer/lib/audio.py
+++ b/infer/lib/audio.py
@@ -4,6 +4,7 @@ import numpy as np
 import av
 from io import BytesIO
 import traceback
+import re
 
 
 def wav2(i, o, format):
@@ -55,4 +56,5 @@ def load_audio(file, sr):
 def clean_path(path_str):
     if platform.system() == "Windows":
         path_str = path_str.replace("/", "\\")
+    path_str = re.sub(r'[\u202a\u202b\u202c\u202d\u202e]', '', path_str)  # 移除 Unicode 控制字符
     return path_str.strip(" ").strip('"').strip("\n").strip('"').strip(" ")


### PR DESCRIPTION
- Bug fix 
修复使用音频文件属性复制文件路径时，带入Unicode 控制字符 导致文件加载失败的bug
