### PR TITLE
fix: Add empty f0 file check to Pipeline.pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ rmvpe.pt
 /assets/weights/*
 ffmpeg.*
 ffprobe.*
+venv

--- a/infer/modules/vc/pipeline.py
+++ b/infer/modules/vc/pipeline.py
@@ -341,11 +341,13 @@ class Pipeline(object):
         if hasattr(f0_file, "name"):
             try:
                 with open(f0_file.name, "r") as f:
-                    lines = f.read().strip("\n").split("\n")
-                inp_f0 = []
-                for line in lines:
-                    inp_f0.append([float(i) for i in line.split(",")])
-                inp_f0 = np.array(inp_f0, dtype="float32")
+                    raw_lines = f.read()
+                    if len(raw_lines) > 0:
+                        lines = raw_lines.strip("\n").split("\n")
+                        inp_f0 = []
+                        for line in lines:
+                            inp_f0.append([float(i) for i in line.split(",")])
+                        inp_f0 = np.array(inp_f0, dtype="float32")
             except:
                 traceback.print_exc()
         sid = torch.tensor(sid, device=self.device).unsqueeze(0).long()


### PR DESCRIPTION
# Pull request checklist

- [X] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [X] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [X] Ensure you can run the codes you submitted succesfully. These submissions will be prioritized for review:

    Introduce improvements in program execution speed;

    Introduce improvements in synthesis quality;

    Fix existing bugs reported by user feedback (or you met);

    Introduce more convenient user operations.

# PR type

- Bug fix / feature change

# Description

- In inference UI, f0 file field is not shown and None is given to API by default. It is also described as optional in AP>
- Using gradio_client to access infer_convert does not allow use of None or empty strings for f0_file.
- Pipeline.pipeline will fault out if the given an empty file for f0 file.
- Added checks when first processing f0_file in Pipeline.pipeline to keep inp_f0 as None on empty files as intended.

# Screenshot

- Please include a screenshot if applicable
