### PR TITLE
Update instructions for AMD ROCM users and fix gradio connection time out issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ pip install -r requirements-dml.txt
 ```
 - A卡ROCM(Linux)
 ```bash
-pip install -r requirements-amd.txt
+pip install -r requirements.txt
 ```
+随后前往 其他预模型准备 中的条目4以安装ROCM驱动程序以及对应的PyTorch版本。
 - I卡IPEX(Linux)
 ```bash
 pip install -r requirements-ipex.txt
@@ -154,7 +155,7 @@ brew install ffmpeg
 
 ### 4. AMD显卡Rocm(可选, 仅Linux)
 
-如果你想基于AMD的Rocm技术在Linux系统上运行RVC，请先在[这里](https://rocm.docs.amd.com/en/latest/deploy/linux/os-native/install.html)安装所需的驱动。
+如果你想基于AMD的Rocm技术在Linux系统上运行RVC，请先在[这里](https://rocm.docs.amd.com/en/latest/deploy/linux/os-native/install.html)安装所需的驱动，随后请访问[这里](https://pytorch.org/get-started/locally/)以安装PyTorch适用于ROCM对应的版本。
 
 若你使用的是Arch Linux，可以使用pacman来安装所需驱动：
 ````
@@ -162,8 +163,8 @@ pacman -S rocm-hip-sdk rocm-opencl-sdk
 ````
 对于某些型号的显卡，你可能需要额外配置如下的环境变量（如：RX6700XT）：
 ````
-export ROCM_PATH=/opt/rocm
-export HSA_OVERRIDE_GFX_VERSION=10.3.0
+export ROCM_PATH=/opt/rocm #Set ROCM Executables Path
+export HSA_OVERRIDE_GFX_VERSION=10.3.0 #Spoof GPU Model for ROCM
 ````
 同时确保你的当前用户处于`render`与`video`用户组内：
 ````

--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ brew install ffmpeg
 
 - 下载[rmvpe.onnx](https://huggingface.co/lj1995/VoiceConversionWebUI/blob/main/rmvpe.onnx)
 
-### 4. AMD显卡Rocm(可选, 仅Linux)
+### 4. AMD显卡ROCM(可选, 仅Linux)
 
-如果你想基于AMD的Rocm技术在Linux系统上运行RVC，请先在[这里](https://rocm.docs.amd.com/en/latest/deploy/linux/os-native/install.html)安装所需的驱动，随后请访问[这里](https://pytorch.org/get-started/locally/)以安装PyTorch适用于ROCM对应的版本。
+如果你想基于AMD的ROCM技术在Linux系统上运行RVC，请先在[这里](https://rocm.docs.amd.com/en/latest/deploy/linux/os-native/install.html)安装所需的驱动，随后请访问[这里](https://pytorch.org/get-started/locally/)以安装PyTorch适用于ROCM对应的版本。
 
 若你使用的是Arch Linux，可以使用pacman来安装所需驱动：
 ````

--- a/docs/en/README.en.md
+++ b/docs/en/README.en.md
@@ -170,9 +170,15 @@ pacman -S rocm-hip-sdk rocm-opencl-sdk
 
 You might also need to set these environment variables (e.g. on a RX6700XT):
 ````
-export ROCM_PATH=/opt/rocm
-export HSA_OVERRIDE_GFX_VERSION=10.3.0
+export ROCM_PATH=/opt/rocm #Set ROCM Executables Path
+export HSA_OVERRIDE_GFX_VERSION=10.3.0 #Spoof GPU Model for ROCM
 ````
+
+And overwrite PyTorch with its ROCM version after installing dependencies.
+````
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.2
+````
+
 Make sure your user is part of the `render` and `video` group:
 ````
 sudo usermod -aG render $USERNAME

--- a/docs/en/README.en.md
+++ b/docs/en/README.en.md
@@ -72,7 +72,7 @@ pip install torch torchvision torchaudio
 #pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu117
 
 #For Linux + AMD Cards, you need to use the following pytorch versions:
-#pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.4.2
+#pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.2
 ```
 
 Then can use poetry to install the other dependencies:

--- a/docs/fr/README.fr.md
+++ b/docs/fr/README.fr.md
@@ -80,7 +80,7 @@ pip install -r requirements-dml.txt
 pip install -r requirements-ipex.txt
 
 # Cartes AMD sur Linux (ROCm)
-pip install -r requirements-amd.txt
+pip install -r requirements.txt
 ```
 
 ------
@@ -150,6 +150,10 @@ Vous devrez peut-être créer ces variables d'environnement (par exemple avec RX
 ````
 export ROCM_PATH=/opt/rocm
 export HSA_OVERRIDE_GFX_VERSION=10.3.0
+````
+Et remplacer PyTorch par sa version ROCM après l'installation des dépendances.
+````
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.2
 ````
 Assurez-vous que votre utilisateur est dans les groupes `render` et `video`:
 ````

--- a/docs/fr/README.fr.md
+++ b/docs/fr/README.fr.md
@@ -55,7 +55,7 @@ pip install torch torchvision torchaudio
 pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu117
 
 # Pour Linux + carte AMD, utilisez cette version de Pytorch:
-pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.4.2
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.2
 ```
 
 Vous pouvez utiliser poetry pour installer les dépendances :

--- a/docs/jp/README.ja.md
+++ b/docs/jp/README.ja.md
@@ -100,7 +100,7 @@ pip install -r requirements-dml.txt
 - A カード ROCM(Linux)
 
 ```bash
-pip install -r requirements-amd.txt
+pip install -r requirements.txt
 ```
 
 - I カード IPEX(Linux)
@@ -201,6 +201,11 @@ pacman -S rocm-hip-sdk rocm-opencl-sdk
 export ROCM_PATH=/opt/rocm
 export HSA_OVERRIDE_GFX_VERSION=10.3.0
 ```
+
+そして、依存関係をインストールした後に、PyTorchをROCMバージョンで上書きする。
+````
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.2
+````
 
 同時に、現在のユーザーが`render`および`video`ユーザーグループに属していることを確認してください。
 

--- a/docs/jp/README.ja.md
+++ b/docs/jp/README.ja.md
@@ -185,9 +185,9 @@ brew install ffmpeg
 
 - [rmvpe.onnx をダウンロード](https://huggingface.co/lj1995/VoiceConversionWebUI/blob/main/rmvpe.onnx)
 
-### 4. AMD グラフィックカード Rocm(オプション、Linux のみ)
+### 4. AMD グラフィックカード ROCM(オプション、Linux のみ)
 
-Linux システムで AMD の Rocm 技術をベースに RVC を実行したい場合、[こちら](https://rocm.docs.amd.com/en/latest/deploy/linux/os-native/install.html)で必要なドライバーを先にインストールしてください。
+Linux システムで AMD の ROCM 技術をベースに RVC を実行したい場合、[こちら](https://rocm.docs.amd.com/en/latest/deploy/linux/os-native/install.html)で必要なドライバーを先にインストールしてください。
 
 Arch Linux を使用している場合、pacman を使用して必要なドライバーをインストールできます。
 

--- a/docs/kr/README.ko.md
+++ b/docs/kr/README.ko.md
@@ -185,9 +185,9 @@ brew install ffmpeg
 
 - [rmvpe.onnx 다운로드](https://huggingface.co/lj1995/VoiceConversionWebUI/blob/main/rmvpe.onnx)
 
-### 4. AMD 그래픽 카드 Rocm(선택사항, Linux만 해당)
+### 4. AMD 그래픽 카드 ROCM(선택사항, Linux만 해당)
 
-Linux 시스템에서 AMD의 Rocm 기술을 기반으로 RVC를 실행하려면 [여기](https://rocm.docs.amd.com/en/latest/deploy/linux/os-native/install.html)에서 필요한 드라이버를 먼저 설치하세요.
+Linux 시스템에서 AMD의 ROCM 기술을 기반으로 RVC를 실행하려면 [여기](https://rocm.docs.amd.com/en/latest/deploy/linux/os-native/install.html)에서 필요한 드라이버를 먼저 설치하세요.
 
 Arch Linux를 사용하는 경우 pacman을 사용하여 필요한 드라이버를 설치할 수 있습니다.
 

--- a/docs/kr/README.ko.md
+++ b/docs/kr/README.ko.md
@@ -100,7 +100,7 @@ pip install -r requirements-dml.txt
 - A카드ROCM(Linux)
 
 ```bash
-pip install -r requirements-amd.txt
+pip install -r requirements.txt
 ```
 
 - I카드IPEX(Linux)
@@ -201,6 +201,12 @@ pacman -S rocm-hip-sdk rocm-opencl-sdk
 export ROCM_PATH=/opt/rocm
 export HSA_OVERRIDE_GFX_VERSION=10.3.0
 ```
+
+그리고 종속 요소를 설치한 후 PyTorch를 ROCM 버전으로 덮어씁니다.
+
+````
+pip 설치 토치 토치비전 토치오디오 --index-url https://download.pytorch.org/whl/rocm6.2
+````
 
 동시에 현재 사용자가 `render` 및 `video` 사용자 그룹에 속해 있는지 확인하세요.
 

--- a/docs/pt/README.pt.md
+++ b/docs/pt/README.pt.md
@@ -89,7 +89,7 @@ for Intel ARC graphics cards on Linux / WSL using Python 3.10:
   pip install -r requirements-ipex.txt
 
 for AMD graphics cards on Linux (ROCm):
-  pip install -r requirements-amd.txt
+  pip install -r requirements.txt
 ```
 
 ------
@@ -165,6 +165,10 @@ Talvez você também precise definir estas variáveis de ambiente (por exemplo, 
 export ROCM_PATH=/opt/rocm
 export HSA_OVERRIDE_GFX_VERSION=10.3.0
 ````
+E substitui o PyTorch pela sua versão ROCM depois de instalar as dependências.a
+````
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.2
+```` 
 Verifique também se seu usuário faz parte do grupo `render` e `video`:
 ````
 sudo usermod -aG render $USERNAME

--- a/docs/pt/README.pt.md
+++ b/docs/pt/README.pt.md
@@ -63,7 +63,7 @@ pip install torch torchvision torchaudio
 #pip instalar tocha torchvision torchaudio --index-url https://download.pytorch.org/whl/cu117
 
 #Para placas Linux + AMD, você precisa usar as seguintes versões do pytorch:
-#pip instalar tocha torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.4.2
+#pip instalar tocha torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.2
 ```
 
 Então pode usar poesia para instalar as outras dependências:

--- a/requirements-amd.txt
+++ b/requirements-amd.txt
@@ -7,7 +7,7 @@ librosa==0.10.2
 llvmlite==0.39.0
 fairseq==0.12.2
 faiss-cpu==1.7.3
-gradio==3.34.0
+gradio==3.48.0
 Cython
 pydub>=0.25.1
 soundfile>=0.12.1

--- a/requirements-dml.txt
+++ b/requirements-dml.txt
@@ -6,7 +6,7 @@ librosa==0.10.2
 llvmlite==0.39.0
 fairseq==0.12.2
 faiss-cpu==1.7.3
-gradio==3.34.0
+gradio==3.48.0
 Cython
 pydub>=0.25.1
 soundfile>=0.12.1

--- a/requirements-ipex.txt
+++ b/requirements-ipex.txt
@@ -11,7 +11,7 @@ librosa==0.10.2
 llvmlite==0.39.0
 fairseq==0.12.2
 faiss-cpu==1.7.3
-gradio==3.34.0
+gradio==3.48.0
 Cython
 pydub>=0.25.1
 soundfile>=0.12.1

--- a/requirements-py311.txt
+++ b/requirements-py311.txt
@@ -6,7 +6,7 @@ librosa==0.10.2
 llvmlite
 fairseq @ git+https://github.com/One-sixth/fairseq.git
 faiss-cpu
-gradio==3.34.0
+gradio==3.48.0
 Cython
 pydub>=0.25.1
 soundfile>=0.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ librosa==0.9.1
 llvmlite==0.39.0
 fairseq==0.12.2
 faiss-cpu==1.7.3
-gradio==3.34.0
+gradio==3.48.0
 Cython
 pydub>=0.25.1
 soundfile>=0.12.1


### PR DESCRIPTION
# Pull request checklist

- [✅] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [✅] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [✅] Ensure you can run the codes you submitted succesfully. These submissions will be prioritized for review:

    Introduce improvements in program execution speed;

    Introduce improvements in synthesis quality;

    Fix existing bugs reported by user feedback (or you met);

    Introduce more convenient user operations.

# PR type

- Revise README instructions.
- Update dependencies.

# Description

- ROCM 6.2.3 is released and comfirmed to works with our project.
- The ROCM version of PyTorch can be a drop-in replacement for CUDA versions, no further changes required.
- Updated gradio is required to fix the connection timeout error in the webui.