### PR TITLE
Update requirements.txt to resolve issue #2116

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,4 +46,4 @@ fastapi==0.88
 torchfcpe
 ffmpy==0.3.1
 python-dotenv>=1.0.0
-av
+av==9.2.0


### PR DESCRIPTION
Recent changes to av have removed support  for "rb" and "rw" as arguments for av.open(). A working fix is to use an older version of av.

# Pull request checklist

- [ #] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [ #] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [ #] Ensure you can run the codes you submitted successfully. These submissions will be prioritized for review:

 
# PR type

- Bug fix for issue #2116

# Description

-av module will be forced to 9.2.0 in requirements.

# Screenshot

- Please include a screenshot if applicable
