### PR TITLE
fix: Make infer-web.py work again: upgrade gradio, restrict versions for torch and matplotlib, fix temp path

### DIFF
--- a/infer-web.py
+++ b/infer-web.py
@@ -31,6 +31,7 @@ import traceback
 import threading
 import shutil
 import logging
+import tempfile
 
 
 logging.getLogger("numba").setLevel(logging.WARNING)
@@ -38,7 +39,7 @@ logging.getLogger("httpx").setLevel(logging.WARNING)
 
 logger = logging.getLogger(__name__)
 
-tmp = os.path.join(now_dir, "TEMP")
+tmp = os.path.join(tempfile.gettempdir(), "RVC")
 shutil.rmtree(tmp, ignore_errors=True)
 shutil.rmtree("%s/runtime/Lib/site-packages/infer_pack" % (now_dir), ignore_errors=True)
 shutil.rmtree("%s/runtime/Lib/site-packages/uvr5_pack" % (now_dir), ignore_errors=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ librosa==0.9.1
 llvmlite==0.39.0
 fairseq==0.12.2
 faiss-cpu==1.7.3
-gradio==3.34.0
+gradio==3.48.0
 Cython
 pydub>=0.25.1
 soundfile>=0.12.1
@@ -16,7 +16,7 @@ tensorboardX
 Jinja2>=3.1.2
 json5
 Markdown
-matplotlib>=3.7.0
+matplotlib<3.10
 matplotlib-inline>=0.1.3
 praat-parselmouth>=0.4.2
 Pillow>=9.1.1
@@ -43,6 +43,7 @@ onnxruntime; sys_platform == 'darwin'
 onnxruntime-gpu; sys_platform != 'darwin'
 torchcrepe==0.0.20
 fastapi==0.88
+torch<2.6
 torchfcpe
 ffmpy==0.3.1
 python-dotenv>=1.0.0


### PR DESCRIPTION
# Pull request checklist

- [x] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [x] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [x] Ensure you can run the codes you submitted succesfully. These submissions will be prioritized for review:

    Introduce improvements in program execution speed;

    Introduce improvements in synthesis quality;

    Fix existing bugs reported by user feedback (or you met);

    Introduce more convenient user operations.

# PR type

- Bug fix

# Description

- **torch** must be older than **2.6**, otherwise there will be errors like this:

  ```
  load model(s) from assets/hubert/hubert_base.pt
  Traceback (most recent call last):
    File "/mnt/ssd_ext4_data/develop/2D_chan/UsefulData/Retrieval-based-Voice-Conversion-WebUI/infer/modules/train/extract_feature_print.py", line 89, in <module>
      models, saved_cfg, task = fairseq.checkpoint_utils.load_model_ensemble_and_task(
    File "/home/tsar/.local/lib/python3.10/site-packages/fairseq/checkpoint_utils.py", line 425, in load_model_ensemble_and_task
      state = load_checkpoint_to_cpu(filename, arg_overrides)
    File "/home/tsar/.local/lib/python3.10/site-packages/fairseq/checkpoint_utils.py", line 315, in load_checkpoint_to_cpu
      state = torch.load(f, map_location=torch.device("cpu"))
    File "/home/tsar/.local/lib/python3.10/site-packages/torch/serialization.py", line 1470, in load
      raise pickle.UnpicklingError(_get_wo_message(str(e))) from None
  _pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint. 
	  (1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
	  (2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
	  WeightsUnpickler error: Unsupported global: GLOBAL fairseq.data.dictionary.Dictionary was not an allowed global by default. Please use `torch.serialization.add_safe_globals([Dictionary])` or the `torch.serialization.safe_globals([Dictionary])` context manager to allowlist this global if you trust this class/function.
  
  Check the documentation of torch.load to learn more about types accepted by default with weights_only https://pytorch.org/docs/stable/generated/torch.load.html.
  ```

- **matplotlib** must be older than **3.10**, otherwise there will be errors like this:

  ```
  Traceback (most recent call last):
    File "/usr/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
      self.run()
    File "/usr/lib/python3.10/multiprocessing/process.py", line 108, in run
      self._target(*self._args, **self._kwargs)
    File "/mnt/ssd_ext4_data/develop/2D_chan/UsefulData/Retrieval-based-Voice-Conversion-WebUI/infer/modules/train/train.py", line 268, in run
      train_and_evaluate(
    File "/mnt/ssd_ext4_data/develop/2D_chan/UsefulData/Retrieval-based-Voice-Conversion-WebUI/infer/modules/train/train.py", line 545, in train_and_evaluate
      "slice/mel_org": utils.plot_spectrogram_to_numpy(
    File "/mnt/ssd_ext4_data/develop/2D_chan/UsefulData/Retrieval-based-Voice-Conversion-WebUI/infer/lib/train/utils.py", line 238, in plot_spectrogram_to_numpy
      data = np.fromstring(fig.canvas.tostring_rgb(), dtype=np.uint8, sep="")
  AttributeError: 'FigureCanvasAgg' object has no attribute 'tostring_rgb'
  ```

- **gradio** should be upgraded, otherwise there will be problems which were reported multiple times: broken "One-click training" button and etc:
  - https://github.com/RVC-Project/Retrieval-based-Voice-Conversion-WebUI/issues/603
  - https://github.com/RVC-Project/Retrieval-based-Voice-Conversion-WebUI/issues/817
  - https://github.com/RVC-Project/Retrieval-based-Voice-Conversion-WebUI/issues/2363

  I upgraded it to **3.48.0** as suggested in https://github.com/RVC-Project/Retrieval-based-Voice-Conversion-WebUI/issues/2355.

  **Warning:** UI starts looking a little bit different after this change! But at least it works.

- Current dir + TEMP + temporary file path might get too long and you may start experiencing errors like this:
  
  ```
  Traceback (most recent call last):
    File "/usr/lib/python3.10/multiprocessing/queues.py", line 244, in _feed
      obj = _ForkingPickler.dumps(obj)
    File "/usr/lib/python3.10/multiprocessing/reduction.py", line 51, in dumps
      cls(buf, protocol).dump(obj)
    File "/usr/local/lib/python3.10/dist-packages/torch/multiprocessing/reductions.py", line 619, in reduce_storage
      df = multiprocessing.reduction.DupFd(fd)
    File "/usr/lib/python3.10/multiprocessing/reduction.py", line 198, in DupFd
      return resource_sharer.DupFd(fd)
    File "/usr/lib/python3.10/multiprocessing/resource_sharer.py", line 53, in __init__
      self._id = _resource_sharer.register(send, close)
    File "/usr/lib/python3.10/multiprocessing/resource_sharer.py", line 76, in register
      self._start()
    File "/usr/lib/python3.10/multiprocessing/resource_sharer.py", line 126, in _start
      self._listener = Listener(authkey=process.current_process().authkey)
    File "/usr/lib/python3.10/multiprocessing/connection.py", line 448, in __init__
      self._listener = SocketListener(address, family, backlog)
    File "/usr/lib/python3.10/multiprocessing/connection.py", line 591, in __init__
      self._socket.bind(address)
  OSError: AF_UNIX path too long
  ```
  That's why I decided to use temporary directory provided by OS instead of hardcoded TEMP inside current dir.

# Screenshot

![image](https://github.com/user-attachments/assets/a7e4b445-5df8-45c5-b00d-fc87d087f047)