### PR TITLE
fix: conflict between global aria2 RPC configuration and aria2c command-line

### DIFF
--- a/tools/dlmodels.sh
+++ b/tools/dlmodels.sh
@@ -33,7 +33,7 @@ check_file_pretrained() {
   else
       echo failed. starting download from huggingface.
       if command -v aria2c > /dev/null 2>&1; then
-          aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/"$1"/"$2" -d ./assets/"$1" -o "$2"
+          aria2c --enable-rpc=false --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/"$1"/"$2" -d ./assets/"$1" -o "$2"
           [ -f "./assets/""$1""/""$2""" ] && echo "download successful." || { echo "please try again!" && exit 1; }
       else
           echo "aria2c command not found. Please install aria2c and try again."
@@ -49,7 +49,7 @@ check_file_special() {
   else
       echo failed. starting download from huggingface.
       if command -v aria2c > /dev/null 2>&1; then
-          aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/"$2" -d ./assets/"$1" -o "$2"
+          aria2c --enable-rpc=false --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/"$2" -d ./assets/"$1" -o "$2"
           [ -f "./assets/""$1""/""$2""" ] && echo "download successful." || { echo "please try again!" && exit 1; }
       else
           echo "aria2c command not found. Please install aria2c and try again."


### PR DESCRIPTION
# Pull request checklist

- [x] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [x] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [x] Ensure you can run the codes you submitted succesfully. These submissions will be prioritized for review:

    Introduce improvements in program execution speed;

    Introduce improvements in synthesis quality;

    Fix existing bugs reported by user feedback (or you met);

    Introduce more convenient user operations.

# PR type

- Bug fix

# Description

The `dlmodels.sh` script uses `aria2c` to download models. When a global aria2 configuration (`~/.aria2/aria2.conf`) exists, the `aria2c` command line reads the global configuration. If the global configuration specifies enabling RPC (which is a common scenario, as global configurations are typically used for aria2's service mode), the `aria2c` command line will also attempt to create an RPC service, resulting in a port conflict. The solution is to add `--enable-rpc=false` to the command line to disable the RPC option for the command-line execution.

