### PR TITLE
fix(tools): prevent aria2c from hanging after downloads in dlmodels.sh

### DIFF
--- a/tools/dlmodels.sh
+++ b/tools/dlmodels.sh
@@ -25,6 +25,8 @@ check_dir "./assets/uvr5_weights/onnx_dereverb_By_FoxJoy"
 
 echo "dir check finished."
 
+ARIA2_OPTS="--no-conf=true --enable-rpc=false --console-log-level=error -c -x 16 -s 16 -k 1M"
+
 echo "required files check start."
 check_file_pretrained() {
   printf "checking %s\n" "$2"
@@ -49,7 +51,7 @@ check_file_special() {
   else
       echo failed. starting download from huggingface.
       if command -v aria2c > /dev/null 2>&1; then
-          aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/"$2" -d ./assets/"$1" -o "$2"
+          aria2c $ARIA2_OPTS https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/"$2" -d ./assets/"$1" -o "$2"
           [ -f "./assets/""$1""/""$2""" ] && echo "download successful." || { echo "please try again!" && exit 1; }
       else
           echo "aria2c command not found. Please install aria2c and try again."


### PR DESCRIPTION
# Pull request checklist

- [x] The PR has a proper title. Use semantic commit style (e.g. fix(tools): ...).
- [x] Make sure this is ready to be merged into the relevant branch.
- [x] Ensure you can run the code you submitted successfully:
    - tools/dlmodels.sh completes and exits after downloads finish (no indefinite wait)

# PR type

- [x] Bug fix

# Description

本次 PR 修复 tools/dlmodels.sh 中 aria2c 下载完成后进程不退出、一直等待的问题。

影响范围：
- 仅影响模型下载脚本的下载流程与退出行为
- 不影响训练/推理逻辑与模型质量

验证方式：
- 本地运行 tools/dlmodels.sh，确认下载完成后脚本会正常结束并返回终端

# Screenshot
before：
![before](https://github.com/user-attachments/assets/14b7ade0-3e34-454b-82da-c18b9f5b5860)

after：
![after](https://github.com/user-attachments/assets/27841b8e-c730-4e76-a16e-607e9a71a611)
