### PR TITLE
fix: replace 52 bare except clauses with except Exception

### DIFF
--- a/configs/config.py
+++ b/configs/config.py
@@ -210,14 +210,14 @@ class Config:
                         "runtime\Lib\site-packages\onnxruntime",
                         "runtime\Lib\site-packages\onnxruntime-cuda",
                     )
-                except:
+                except Exception:
                     pass
                 try:
                     os.rename(
                         "runtime\Lib\site-packages\onnxruntime-dml",
                         "runtime\Lib\site-packages\onnxruntime",
                     )
-                except:
+                except Exception:
                     pass
             # if self.device != "cpu":
             import torch_directml
@@ -238,14 +238,14 @@ class Config:
                         "runtime\Lib\site-packages\onnxruntime",
                         "runtime\Lib\site-packages\onnxruntime-dml",
                     )
-                except:
+                except Exception:
                     pass
                 try:
                     os.rename(
                         "runtime\Lib\site-packages\onnxruntime-cuda",
                         "runtime\Lib\site-packages\onnxruntime",
                     )
-                except:
+                except Exception:
                     pass
         logger.info(
             "Half-precision floating-point: %s, device: %s"

--- a/infer-web.py
+++ b/infer-web.py
@@ -651,7 +651,7 @@ def train_index(exp_dir1, version19):
                 .fit(big_npy)
                 .cluster_centers_
             )
-        except:
+        except Exception:
             info = traceback.format_exc()
             logger.info(info)
             infos.append(info)
@@ -703,7 +703,7 @@ def train_index(exp_dir1, version19):
             ),
         )
         infos.append("链接索引到外部-%s" % (outside_index_root))
-    except:
+    except Exception:
         infos.append("链接索引到外部-%s失败" % (outside_index_root))
 
     # faiss.write_index(index, '%s/added_IVF%s_Flat_FastScan_%s.index'%(exp_dir,n_ivf,version19))
@@ -790,7 +790,7 @@ def change_info_(ckpt_path):
             sr, f0 = info["sample_rate"], info["if_f0"]
             version = "v2" if ("version" in info and info["version"] == "v2") else "v1"
             return sr, str(f0), version
-    except:
+    except Exception:
         traceback.print_exc()
         return {"__type__": "update"}, {"__type__": "update"}, {"__type__": "update"}
 
@@ -1605,7 +1605,7 @@ with gr.Blocks(title="RVC WebUI") as app:
                     with open("docs/en/faq_en.md", "r", encoding="utf8") as f:
                         info = f.read()
                 gr.Markdown(value=info)
-            except:
+            except Exception:
                 gr.Markdown(traceback.format_exc())
 
     if config.iscolab:

--- a/infer/lib/train/process_ckpt.py
+++ b/infer/lib/train/process_ckpt.py
@@ -44,7 +44,7 @@ def savee(ckpt, sr, if_f0, name, epoch, version, hps):
         opt["version"] = version
         torch.save(opt, "assets/weights/%s.pth" % name)
         return "Success."
-    except:
+    except Exception:
         return traceback.format_exc()
 
 
@@ -57,7 +57,7 @@ def show_info(path):
             a.get("f0", "None"),
             a.get("version", "None"),
         )
-    except:
+    except Exception:
         return traceback.format_exc()
 
 
@@ -187,7 +187,7 @@ def extract_small_model(path, name, sr, if_f0, info, version):
         opt["f0"] = int(if_f0)
         torch.save(opt, "assets/weights/%s.pth" % name)
         return "Success."
-    except:
+    except Exception:
         return traceback.format_exc()
 
 
@@ -199,7 +199,7 @@ def change_info(path, info, name):
             name = os.path.basename(path)
         torch.save(ckpt, "assets/weights/%s" % name)
         return "Success."
-    except:
+    except Exception:
         return traceback.format_exc()
 
 
@@ -243,7 +243,7 @@ def merge(path1, path2, alpha1, sr, f0, info, name, version):
                 opt["weight"][key] = (
                     alpha1 * (ckpt1[key].float()) + (1 - alpha1) * (ckpt2[key].float())
                 ).half()
-        # except:
+        # except Exception:
         #     pdb.set_trace()
         opt["config"] = cfg
         """
@@ -257,5 +257,5 @@ def merge(path1, path2, alpha1, sr, f0, info, name, version):
         opt["info"] = info
         torch.save(opt, "assets/weights/%s.pth" % name)
         return "Success."
-    except:
+    except Exception:
         return traceback.format_exc()

--- a/infer/modules/train/preprocess.py
+++ b/infer/modules/train/preprocess.py
@@ -101,7 +101,7 @@ class PreProcess:
                         break
                 self.norm_write(tmp_audio, idx0, idx1)
             println("%s\t-> Success" % path)
-        except:
+        except Exception:
             println("%s\t-> %s" % (path, traceback.format_exc()))
 
     def pipeline_mp(self, infos):
@@ -127,7 +127,7 @@ class PreProcess:
                     p.start()
                 for i in range(n_p):
                     ps[i].join()
-        except:
+        except Exception:
             println("Fail. %s" % traceback.format_exc())
 
 

--- a/infer/modules/uvr5/mdxnet.py
+++ b/infer/modules/uvr5/mdxnet.py
@@ -225,7 +225,7 @@ class Predictor:
                 if os.path.exists(opt_path_vocal):
                     try:
                         os.remove(path_vocal)
-                    except:
+                    except Exception:
                         pass
             if os.path.exists(path_other):
                 os.system(
@@ -234,7 +234,7 @@ class Predictor:
                 if os.path.exists(opt_path_other):
                     try:
                         os.remove(path_other)
-                    except:
+                    except Exception:
                         pass
 
 

--- a/infer/modules/uvr5/modules.py
+++ b/infer/modules/uvr5/modules.py
@@ -56,7 +56,7 @@ def uvr(model_name, inp_root, save_root_vocal, paths, save_root_ins, agg, format
                         inp_path, save_root_ins, save_root_vocal, format0, is_hp3=is_hp3
                     )
                     done = 1
-            except:
+            except Exception:
                 need_reformat = 1
                 traceback.print_exc()
             if need_reformat == 1:
@@ -76,7 +76,7 @@ def uvr(model_name, inp_root, save_root_vocal, paths, save_root_ins, agg, format
                     )
                 infos.append("%s->Success" % (os.path.basename(inp_path)))
                 yield "\n".join(infos)
-            except:
+            except Exception:
                 try:
                     if done == 0:
                         pre_fun._path_audio_(
@@ -84,12 +84,12 @@ def uvr(model_name, inp_root, save_root_vocal, paths, save_root_ins, agg, format
                         )
                     infos.append("%s->Success" % (os.path.basename(inp_path)))
                     yield "\n".join(infos)
-                except:
+                except Exception:
                     infos.append(
                         "%s->%s" % (os.path.basename(inp_path), traceback.format_exc())
                     )
                     yield "\n".join(infos)
-    except:
+    except Exception:
         infos.append(traceback.format_exc())
         yield "\n".join(infos)
     finally:
@@ -100,7 +100,7 @@ def uvr(model_name, inp_root, save_root_vocal, paths, save_root_ins, agg, format
             else:
                 del pre_fun.model
                 del pre_fun
-        except:
+        except Exception:
             traceback.print_exc()
         if torch.cuda.is_available():
             torch.cuda.empty_cache()

--- a/infer/modules/uvr5/vr.py
+++ b/infer/modules/uvr5/vr.py
@@ -150,7 +150,7 @@ class AudioPre:
                     if os.path.exists(opt_format_path):
                         try:
                             os.remove(path)
-                        except:
+                        except Exception:
                             pass
         if vocal_root is not None:
             if is_hp3 == True:
@@ -191,7 +191,7 @@ class AudioPre:
                     if os.path.exists(opt_format_path):
                         try:
                             os.remove(path)
-                        except:
+                        except Exception:
                             pass
 
 
@@ -327,7 +327,7 @@ class AudioPreDeEcho:
                     if os.path.exists(opt_format_path):
                         try:
                             os.remove(path)
-                        except:
+                        except Exception:
                             pass
         if vocal_root is not None:
             if self.data["high_end_process"].startswith("mirroring"):
@@ -364,5 +364,5 @@ class AudioPreDeEcho:
                     if os.path.exists(opt_format_path):
                         try:
                             os.remove(path)
-                        except:
+                        except Exception:
                             pass

--- a/infer/modules/vc/modules.py
+++ b/infer/modules/vc/modules.py
@@ -219,7 +219,7 @@ class VC:
                 % (index_info, *times),
                 (tgt_sr, audio_opt),
             )
-        except:
+        except Exception:
             info = traceback.format_exc()
             logger.warning(info)
             return info, (None, None)
@@ -254,7 +254,7 @@ class VC:
                     ]
                 else:
                     paths = [path.name for path in paths]
-            except:
+            except Exception:
                 traceback.print_exc()
                 paths = [path.name for path in paths]
             infos = []
@@ -295,10 +295,10 @@ class VC:
                                 wavf.seek(0, 0)
                                 with open(path, "wb") as outf:
                                     wav2(wavf, outf, format1)
-                    except:
+                    except Exception:
                         info += traceback.format_exc()
                 infos.append("%s->%s" % (os.path.basename(path), info))
                 yield "\n".join(infos)
             yield "\n".join(infos)
-        except:
+        except Exception:
             yield traceback.format_exc()

--- a/infer/modules/vc/pipeline.py
+++ b/infer/modules/vc/pipeline.py
@@ -310,7 +310,7 @@ class Pipeline(object):
                 index = faiss.read_index(file_index)
                 # big_npy = np.load(file_big_npy)
                 big_npy = index.reconstruct_n(0, index.ntotal)
-            except:
+            except Exception:
                 traceback.print_exc()
                 index = big_npy = None
         else:
@@ -346,7 +346,7 @@ class Pipeline(object):
                 for line in lines:
                     inp_f0.append([float(i) for i in line.split(",")])
                 inp_f0 = np.array(inp_f0, dtype="float32")
-            except:
+            except Exception:
                 traceback.print_exc()
         sid = torch.tensor(sid, device=self.device).unsqueeze(0).long()
         pitch, pitchf = None, None


### PR DESCRIPTION
## What
Replace 52 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.