### PR TITLE
fix(vc): avoid duplicate output extensions

### DIFF
--- a/infer/modules/vc/modules.py
+++ b/infer/modules/vc/modules.py
@@ -1,3 +1,4 @@
+import os
 import traceback
 import logging
 
@@ -277,23 +278,24 @@ class VC:
                 if "Success" in info:
                     try:
                         tgt_sr, audio_opt = opt
+                        input_name = os.path.basename(path)
+                        clean_name = os.path.splitext(input_name)[0]
                         if format1 in ["wav", "flac"]:
                             sf.write(
-                                "%s/%s.%s"
-                                % (opt_root, os.path.basename(path), format1),
+                                "%s/%s.%s" % (opt_root, clean_name, format1),
                                 audio_opt,
                                 tgt_sr,
                             )
                         else:
-                            path = "%s/%s.%s" % (
+                            save_path = "%s/%s.%s" % (
                                 opt_root,
-                                os.path.basename(path),
+                                clean_name,
                                 format1,
                             )
                             with BytesIO() as wavf:
                                 sf.write(wavf, audio_opt, tgt_sr, format="wav")
                                 wavf.seek(0, 0)
-                                with open(path, "wb") as outf:
+                                with open(save_path, "wb") as outf:
                                     wav2(wavf, outf, format1)
                     except:
                         info += traceback.format_exc()


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Strip an existing source extension before appending the selected export format in `vc_multi`
- Avoid writing files like `song.wav.wav` when the input file is already a WAV/FLAC/etc.
- Preserve the original input path for status reporting by using a separate `save_path` variable for converted formats

Fixes RVC-Project/Retrieval-based-Voice-Conversion-WebUI#2758.

## Test Plan
- `python3 -m py_compile /tmp/rvc_2758_patchwork/infer/modules/vc/modules.py`
- Local filename behavior check:
  - `song.wav` + `wav` -> `song.wav`
  - `song.flac` + `flac` -> `song.flac`
  - `song.mp3` + `wav` -> `song.wav`
  - `dir/song.wav` + `mp3` -> `song.mp3`

## Notes
- This is a minimal WebUI/export path fix and does not touch model inference or algorithm logic.
